### PR TITLE
Fix Logic Unit formula triggers for v1.10.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to Smart (Components) Toolkit for Homey will be documented i
 
 ---
 
+## [1.10.23] - August 2026 (Test channel)
+
+### Added
+- Added a Logic Unit **Formula changed** trigger for every TRUE/FALSE transition, with current and previous result tags.
+- Added a working **Formula changed to...** trigger filtered by selected formula and TRUE/FALSE result.
+
+### Fixed
+- Logic Unit now synchronizes its read-only **Formula result** (`alarm_generic`) alarm with the aggregate result, restoring Homey's standard alarm turned on/off triggers.
+- Restored the original pre-Compose formula trigger IDs for existing flows and corrected current trigger registration and formula filtering.
+
+---
+
 ## [1.10.22] - August 2026 (Test channel)
 
 ### Added

--- a/HOMEY_COMMUNITY_LISTING.md
+++ b/HOMEY_COMMUNITY_LISTING.md
@@ -1,11 +1,11 @@
-URL: https://community.homey.app/t/app-smart-components-toolkit-was-boolean-toolbox-create-advanced-logic-with-simple-formulas/143906
+URL: https://community.homey.app/t/app-smart-components-toolkit-was-boolean-toolbox-create-advanced-logic-with-simple-formulas-v1-10-16-store-v1-10-23-test-logic-unit-fixes/143906
 
-Title: [APP] Smart (Components) Toolkit (was: Boolean Toolbox) - Create advanced logic with simple formulas [v1.10.16 store / v1.10.22 test - Composite Device]
+Title: [APP] Smart (Components) Toolkit (was: Boolean Toolbox) - Create advanced logic with simple formulas [v1.10.16 store / v1.10.23 test - Logic Unit fixes]
 
 Content:
 ![xlarge|690x483](upload://iSxhJPUltgcgPQ7gy4z5iisCv5F.jpeg)
 
-# Smart (Components) Toolkit — store v1.10.16 / test v1.10.22
+# Smart (Components) Toolkit — store v1.10.16 / test v1.10.23
 
 > **📚 Full Documentation:** https://tiwas.github.io/SmartComponentsToolkit/
 
@@ -16,6 +16,13 @@ Replace complex flow networks with powerful logic devices controlled by dynamic 
 ---
 
 ## What's new
+
+### v1.10.23 (test channel)
+
+- **Logic Unit alarm restored:** the read-only Formula result alarm now follows the combined result of all enabled formulas, so Homey's standard generic-alarm turned on/off cards work again.
+- **New Formula changed card:** fires on every TRUE/FALSE transition for the selected formula and provides the current and previous result as tags.
+- **Fixed Formula changed to... card:** correctly filters on both the selected formula and the chosen TRUE/FALSE result.
+- Existing formula-trigger IDs are retained for backwards compatibility with saved flows.
 
 ### v1.10.22 (test channel)
 
@@ -63,7 +70,7 @@ THEN: Set fan speed to Mapped value
 
 ## ✨ Circadian Light Group — now on stable
 
-A virtual **light device** that adjusts brightness and color temperature for a group of real lights — automatically following a circadian rhythm. Store is currently v1.10.16; v1.10.22 is available on the test channel.
+A virtual **light device** that adjusts brightness and color temperature for a group of real lights — automatically following a circadian rhythm. Store is currently v1.10.16; v1.10.23 is available on the test channel.
 
 ### Circadian Light Group highlights
 
@@ -115,7 +122,7 @@ Choose how the device knows how bright it is outside:
 
 <a href="https://homey.app/en-no/app/no.tiwas.booleantoolbox/" target="_blank">→ Install store v1.10.16</a>
 <br>
-<a href="https://homey.app/a/no.tiwas.booleantoolbox/test/" target="_blank">→ Install test v1.10.22</a>
+<a href="https://homey.app/a/no.tiwas.booleantoolbox/test/" target="_blank">→ Install test v1.10.23</a>
 
 ---
 
@@ -188,7 +195,7 @@ THEN: Wait until coffee machine temperature ≥ 90°C (timeout 5 min)
 ## Installation and Links
 
 * **Homey App Store (v1.10.16):** <a href="https://homey.app/en-no/app/no.tiwas.booleantoolbox/" target="_blank">Install Smart (Components) Toolkit</a>
-* **Test channel (v1.10.22):** <a href="https://homey.app/a/no.tiwas.booleantoolbox/test/" target="_blank">Install test version</a>
+* **Test channel (v1.10.23):** <a href="https://homey.app/a/no.tiwas.booleantoolbox/test/" target="_blank">Install test version</a>
 * **GitHub Repo:** <a href="https://github.com/tiwas/SmartComponentsToolkit" target="_blank">github.com/tiwas/SmartComponentsToolkit</a>
 * **Online Emulator:** <a href="https://tiwas.github.io/SmartComponentsToolkit/tools/emulator.html" target="_blank">Boolean Logic Emulator</a>
 * **Formula Builder:** <a href="https://tiwas.github.io/SmartComponentsToolkit/tools/formula-builder.html" target="_blank">Formula Builder</a>

--- a/PROJECT_DOCUMENTATION.md
+++ b/PROJECT_DOCUMENTATION.md
@@ -9,6 +9,7 @@
 *   **Logic Device:** A user-friendly device with a visual pairing wizard. Best for simple setups and single formulas. Features dynamic inputs (2-10).
 *   **Logic Unit:** Targeted at advanced users. Configured via JSON settings. Supports multiple independent formulas within a single unit.
 *   **Legacy Units:** Supports legacy "Logic Unit X" devices (fixed input counts).
+*   **Logic Unit output and triggers:** `alarm_generic` exposes the aggregate result (TRUE when any enabled formula is TRUE). `formula_changed_lu` fires on any selected-formula transition, while `formula_changed_to_lu` additionally filters by the selected TRUE/FALSE result. Deprecated trigger IDs remain registered for saved Flow compatibility.
 
 ### 2. Formula Engine
 *   **Location:** `no.tiwas.booleantoolbox/lib/FormulaEvaluator.js`
@@ -38,7 +39,7 @@
     *   `lib/`: Core logic libraries (`CompositeAggregator.js`, `FormulaEvaluator.js`, `Logger.js`).
     *   `locales/`: Translation files.
 *   `docs/`: Documentation for the GitHub Pages site.
-*   Jest test files live beside the app source, including `CompositeAggregator.test.js`, `CompositeDevice.test.js`, and `FormulaEvaluator.test.js`.
+*   Jest test files live beside the app source, including `CompositeAggregator.test.js`, `CompositeDevice.test.js`, `FormulaEvaluator.test.js`, and `LogicUnit.test.js`.
 
 ## Key Technologies
 *   **Platform:** Homey (Athom).

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 Advanced logic and state management for your Homey automations. Create smart devices that react to multiple inputs with customizable formulas, and manage device states with powerful capture/restore functionality.
 
 [![Stable](https://img.shields.io/badge/stable-1.10.9-blue.svg)](https://homey.app/en-no/app/no.tiwas.booleantoolbox/)
-[![Test](https://img.shields.io/badge/test-1.10.22-orange.svg)](https://homey.app/a/no.tiwas.booleantoolbox/test/)
+[![Test](https://img.shields.io/badge/test-1.10.23-orange.svg)](https://homey.app/a/no.tiwas.booleantoolbox/test/)
 [![Homey](https://img.shields.io/badge/Homey-5.0+-green.svg)](https://homey.app)
 
-> **v1.10.22 test** — adds Composite Device Flow triggers for every exposed value change and for numeric changes above a configurable fixed or percentage threshold.
+> **v1.10.23 test** — restores the Logic Unit formula-result alarm and adds reliable **Formula changed** and **Formula changed to...** triggers with current and previous result tags.
 
 ---
 
@@ -138,7 +138,7 @@ THEN: Pop state (restore previous)
 
 ---
 
-### Circadian Light Group *(stable v1.10.16 / test v1.10.22)*
+### Circadian Light Group *(stable v1.10.16 / test v1.10.23)*
 
 Virtual light device that adjusts brightness and color temperature for a group of real lights based on time, sun position or ambient lux.
 

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -91,3 +91,57 @@
 - Uploaded Homey Build 51 as v1.10.22 and published it to the test channel.
 - Installed v1.10.22 successfully on `Lars's New Homey` after debug-level validation.
 - Prepared the v1.10.22 source, documentation, and community listing update for the GitHub release commit.
+
+## 2026-08-12 — Logic Unit generic-alarm trigger diagnosis
+
+### Requested
+- Determine whether a Logic Unit using `A+B` should trigger Homey's generic-alarm-turned-on card after an input is set to TRUE, or whether the wrong Flow card was used.
+
+### Findings
+- Confirmed that `+` is a supported OR operator, so either A or B being TRUE makes `A+B` TRUE once both required inputs have values.
+- Confirmed that the current Logic Unit evaluator stores the formula result but never writes the aggregate result to `alarm_generic`; even the aggregate state calculated during full reevaluation is unused.
+- Confirmed that published documentation defines `alarm_generic` as the formula result and that the older backup implementation updated it, identifying this as a Logic Unit regression rather than user misuse.
+- Found a second inconsistency in the formula-specific trigger path: the evaluator triggers undeclared device-card IDs while the registered combined card has a different app-trigger ID. It should therefore not be presented as a reliable workaround until fixed.
+- The generic alarm card should work according to the exposed capability contract; for multiple formulas, its intended state is the aggregate OR result (TRUE when any enabled formula is TRUE).
+
+### Verification
+- `npm test -- --runTestsByPath FormulaEvaluator.test.js --runInBand`: 1 suite, 52 tests passed, including `A + B` tokenization and evaluation coverage.
+- No production code was changed during this diagnostic session.
+
+## 2026-08-12 — Logic Unit formula-change Flow cards and alarm fix
+
+### Requested
+- Add a new **Formula changed to...** card and repair the **Formula changed** behavior.
+
+### Implemented
+- Added a formula-specific **Formula changed** trigger for every TRUE/FALSE transition and repaired **Formula changed to...** with correct device-trigger registration, formula matching, and result filtering.
+- Added current and previous boolean result tokens to both cards.
+- Restored the original pre-Compose TRUE/FALSE trigger IDs as deprecated compatibility cards and retained the newer deprecated aliases.
+- Synchronized `alarm_generic` with the aggregate Logic Unit result, defined as TRUE whenever any enabled formula is TRUE, so Homey's standard alarm turned on/off cards work again.
+- Renamed the Dynamic Logic Unit capability from the generic Homey label to **Formula result** and updated Flow-card/device documentation.
+
+### Verification
+- Added Logic Unit regression tests covering `A+B`, aggregate alarm behavior, trigger payloads, selected-formula filtering, and TRUE/FALSE result filtering.
+- Focused test run: 2 suites and 55 tests passed.
+- Full test run: 8 suites and 139 tests passed.
+- All changed Flow-card and driver Compose JSON parsed successfully; changed JavaScript files passed `node --check`.
+- `homey app validate` passed at publish level with both current cards and all compatibility IDs included for every Logic Unit driver.
+
+## 2026-08-12 — Logic Unit fix release v1.10.23
+
+### Requested
+- Publish and install the Logic Unit fix, update GitHub, and update the existing Homey Community topic.
+
+### Implemented
+- Versioned the Homey app and release documentation as v1.10.23.
+- Added the Logic Unit alarm and formula-trigger fixes to the Homey changelog, repository changelog, README, documentation version badges, and community-listing source.
+
+### Verification
+- `npm test -- --runInBand`: 8 suites, 139 tests passed.
+- `homey app validate`: passed at publish level.
+- Homey Developer Tools confirmed Build 52 as v1.10.23 and showed both `Formula changed` and `Formula changed to...` in the submitted manifest.
+
+### Release
+- Uploaded Homey Build 52 and published v1.10.23 to the test channel.
+- Installed the app successfully on `Lars's New Homey` with `homey app install`.
+- Updated and verified the existing Homey Community topic with the v1.10.23 title and release notes.

--- a/docs/docs/circadian-light-group.html
+++ b/docs/docs/circadian-light-group.html
@@ -73,7 +73,7 @@
     <main class="max-w-3xl mx-auto px-6 py-8 flex-grow">
         <div class="flex items-center gap-3 mb-2">
             <h1 class="text-4xl font-bold text-gray-900">Circadian Light Group</h1>
-            <span class="bg-purple-100 text-purple-700 text-xs font-semibold px-2 py-1 rounded">v1.10.22 test</span>
+            <span class="bg-purple-100 text-purple-700 text-xs font-semibold px-2 py-1 rounded">v1.10.23 test</span>
         </div>
         <p class="text-gray-600 mb-8">A virtual light device that automatically adjusts brightness and color temperature throughout the day based on time, sun position or ambient light, with an optional red mode for night use.</p>
 

--- a/docs/docs/composite-device.html
+++ b/docs/docs/composite-device.html
@@ -62,7 +62,7 @@
             <div class="bg-amber-50 border-l-4 border-amber-500 p-4 mt-5 rounded text-amber-900">
                 The source list and operation are fixed when the device is created. To use a different set, add another Composite Device.
             </div>
-            <p class="mt-5"><a href="https://homey.app/a/no.tiwas.booleantoolbox/test/" class="text-purple-600 hover:text-purple-800 font-semibold">Install test version v1.10.22 &rarr;</a></p>
+            <p class="mt-5"><a href="https://homey.app/a/no.tiwas.booleantoolbox/test/" class="text-purple-600 hover:text-purple-800 font-semibold">Install latest test version (v1.10.23) &rarr;</a></p>
         </section>
 
         <section class="bg-white rounded-lg p-6 mb-6 shadow-sm border border-gray-200">

--- a/docs/docs/devices.html
+++ b/docs/docs/devices.html
@@ -282,7 +282,7 @@
                 <li>Add <strong>Logic Unit (Dynamic)</strong> from Smart (Components) Toolkit.</li>
                 <li>Open the device's Advanced Settings and enter a JSON array in <strong>Formulas (JSON)</strong>. Inputs are the letters A through J.</li>
                 <li>In a Flow, use <strong>Set input value for formula</strong> to set each input true or false. Use both the true and false branches of the source card so the Logic Unit always receives the current state.</li>
-                <li>Use <strong>Formula result changed</strong> as a WHEN card, or <strong>Formula result is</strong> as an AND card.</li>
+                <li>Use <strong>Formula changed</strong> or <strong>Formula changed to...</strong> as a WHEN card, or <strong>Formula result is</strong> as an AND card.</li>
             </ol>
 
             <div class="grid md:grid-cols-2 gap-4 mt-4">
@@ -309,11 +309,12 @@
                         <h3 class="font-semibold text-purple-700">alarm_generic</h3>
                         <span class="text-xs bg-gray-200 text-gray-700 px-2 py-1 rounded">boolean</span>
                     </div>
-                    <p class="text-gray-700 mb-2">The formula result (true/false)</p>
+                    <p class="text-gray-700 mb-2">The aggregate formula result (true when any enabled formula is true)</p>
                     <ul class="text-sm text-gray-600 ml-4 space-y-1">
-                        <li>• Used to trigger flows when formula result changes</li>
+                        <li>• Exposed as the read-only <strong>Formula result</strong> alarm</li>
+                        <li>• Can trigger Homey's standard alarm turned on/off cards</li>
                         <li>• Read-only (changes based on formula evaluation)</li>
-                        <li>• Each formula has its own result state</li>
+                        <li>• Use the formula-specific Flow cards when a Logic Unit contains multiple formulas</li>
                     </ul>
                 </div>
 

--- a/docs/docs/flow-cards.html
+++ b/docs/docs/flow-cards.html
@@ -77,7 +77,8 @@
                     <ul class="text-sm space-y-1 text-gray-700">
                         <li><a href="#trigger-composite-changed" class="hover:text-purple-600">→ Composite value changed</a></li>
                         <li><a href="#trigger-composite-threshold" class="hover:text-purple-600">→ Composite threshold</a></li>
-                        <li><a href="#trigger-formula-changed" class="hover:text-purple-600">→ Formula changed to...</a></li>
+                        <li><a href="#trigger-formula-changed" class="hover:text-purple-600">→ Formula changed</a></li>
+                        <li><a href="#trigger-formula-changed-to" class="hover:text-purple-600">→ Formula changed to...</a></li>
                         <li><a href="#trigger-state-changed" class="hover:text-purple-600">→ State changed (LD)</a></li>
                         <li><a href="#trigger-timeout" class="hover:text-purple-600">→ Formula timed out</a></li>
                     </ul>
@@ -156,14 +157,38 @@
 
             <!-- Formula Changed -->
             <div id="trigger-formula-changed" class="bg-white rounded-lg p-6 mb-6 shadow-sm border border-gray-200">
-                <h3 class="text-xl font-semibold mb-3 text-purple-700">Formula [formula] changed to [state]</h3>
-                <p class="text-gray-700 mb-4">Triggers when a formula evaluation result changes to TRUE or FALSE.</p>
+                <h3 class="text-xl font-semibold mb-3 text-purple-700">Formula [formula] changed</h3>
+                <p class="text-gray-700 mb-4">Triggers on every transition between TRUE and FALSE for the selected Logic Unit formula.</p>
 
                 <div class="flow-card">
                     <p class="text-sm text-gray-600 mb-2">Parameters:</p>
                     <ul class="space-y-2 text-gray-800">
-                        <li><span class="code-inline">formula</span> - Select which formula to monitor (dropdown)</li>
-                        <li><span class="code-inline">state</span> - TRUE or FALSE (dropdown)</li>
+                        <li><span class="code-inline">formula</span> - Select which formula to monitor</li>
+                    </ul>
+                    <p class="text-sm text-gray-600 mt-3 mb-2">Tokens:</p>
+                    <ul class="space-y-2 text-gray-800">
+                        <li><span class="code-inline">result</span> - New result</li>
+                        <li><span class="code-inline">previous_result</span> - Previous result</li>
+                        <li><span class="code-inline">formula_name</span> / <span class="code-inline">device_name</span></li>
+                    </ul>
+                </div>
+            </div>
+
+            <!-- Formula Changed To -->
+            <div id="trigger-formula-changed-to" class="bg-white rounded-lg p-6 mb-6 shadow-sm border border-gray-200">
+                <h3 class="text-xl font-semibold mb-3 text-purple-700">Formula [formula] changed to [result]</h3>
+                <p class="text-gray-700 mb-4">Triggers only when the selected Logic Unit formula changes to the selected TRUE or FALSE result.</p>
+
+                <div class="flow-card">
+                    <p class="text-sm text-gray-600 mb-2">Parameters:</p>
+                    <ul class="space-y-2 text-gray-800">
+                        <li><span class="code-inline">formula</span> - Select which formula to monitor</li>
+                        <li><span class="code-inline">result</span> - TRUE or FALSE</li>
+                    </ul>
+                    <p class="text-sm text-gray-600 mt-3 mb-2">Tokens:</p>
+                    <ul class="space-y-2 text-gray-800">
+                        <li><span class="code-inline">result</span> - New result</li>
+                        <li><span class="code-inline">previous_result</span> - Previous result</li>
                     </ul>
                 </div>
 
@@ -174,7 +199,7 @@
                 </div>
 
                 <div class="bg-blue-50 border-l-4 border-blue-500 p-3 mt-4 rounded">
-                    <p class="text-blue-800 text-sm">💡 Available for both Logic Device and Logic Unit</p>
+                    <p class="text-blue-800 text-sm">The first complete evaluation establishes the formula baseline. These cards fire on later TRUE↔FALSE transitions. Use the Logic Unit's Formula result alarm when a Flow must also react when the first complete result becomes TRUE.</p>
                 </div>
             </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -57,7 +57,7 @@
             </div>
             <div class="flex justify-center gap-2 flex-wrap">
                 <span class="bg-purple-800 text-white text-sm px-3 py-1 rounded">v1.10.9 stable</span>
-                <a href="https://homey.app/a/no.tiwas.booleantoolbox/test/" class="bg-amber-500 hover:bg-amber-600 text-white text-sm px-3 py-1 rounded">v1.10.22 test</a>
+                <a href="https://homey.app/a/no.tiwas.booleantoolbox/test/" class="bg-amber-500 hover:bg-amber-600 text-white text-sm px-3 py-1 rounded">v1.10.23 test</a>
                 <span class="bg-green-600 text-white text-sm px-3 py-1 rounded">Homey 5.0+</span>
             </div>
         </div>
@@ -286,7 +286,7 @@ THEN: Pop state (restore previous)</pre>
             <div class="bg-white rounded-lg p-6 shadow-sm border border-gray-200 mb-6">
                 <div class="flex items-center gap-3 mb-4">
                     <h3 class="text-xl font-semibold text-purple-600">Circadian Light Group</h3>
-                    <span class="bg-purple-100 text-purple-700 text-xs font-semibold px-2 py-1 rounded">v1.10.22 test</span>
+                    <span class="bg-purple-100 text-purple-700 text-xs font-semibold px-2 py-1 rounded">v1.10.23 test</span>
                 </div>
                 <p class="text-gray-700 mb-4">A virtual light device that automatically adjusts brightness and color temperature for a group of real lights based on time of day, sun position or ambient light, with optional red mode at night.</p>
                 <div class="overflow-x-auto mb-4">

--- a/no.tiwas.booleantoolbox/.homeychangelog.json
+++ b/no.tiwas.booleantoolbox/.homeychangelog.json
@@ -115,5 +115,8 @@
   },
   "1.10.22": {
     "en": "Add Composite Device Flow triggers for every value change and for numeric changes larger than a configurable fixed or percentage threshold."
+  },
+  "1.10.23": {
+    "en": "Fix Logic Unit formula result alarms and formula-change triggers. Adds Formula changed and Formula changed to Flow cards with current and previous result tags."
   }
 }

--- a/no.tiwas.booleantoolbox/.homeycompose/flow/triggers/formula_changed_lu.json
+++ b/no.tiwas.booleantoolbox/.homeycompose/flow/triggers/formula_changed_lu.json
@@ -1,0 +1,68 @@
+{
+  "id": "formula_changed_lu",
+  "title": {
+    "en": "Formula changed",
+    "no": "Formel endret"
+  },
+  "titleFormatted": {
+    "en": "Formula [[formula]] changed",
+    "no": "Formel [[formula]] endret"
+  },
+  "hint": {
+    "en": "Triggers whenever the selected formula changes between TRUE and FALSE.",
+    "no": "Utløses hver gang den valgte formelen endres mellom SANN og USANN."
+  },
+  "args": [
+    {
+      "type": "device",
+      "name": "device",
+      "filter": "driver_id=logic-unit|logic-unit-2|logic-unit-3|logic-unit-4|logic-unit-5|logic-unit-6|logic-unit-7|logic-unit-8|logic-unit-9|logic-unit-10"
+    },
+    {
+      "type": "autocomplete",
+      "name": "formula",
+      "title": {
+        "en": "Formula",
+        "no": "Formel"
+      },
+      "placeholder": {
+        "en": "Select a formula...",
+        "no": "Velg en formel..."
+      }
+    }
+  ],
+  "tokens": [
+    {
+      "name": "device_name",
+      "type": "string",
+      "title": {
+        "en": "Device name",
+        "no": "Enhetsnavn"
+      }
+    },
+    {
+      "name": "formula_name",
+      "type": "string",
+      "title": {
+        "en": "Formula name",
+        "no": "Formelnavn"
+      }
+    },
+    {
+      "name": "result",
+      "type": "boolean",
+      "title": {
+        "en": "Result",
+        "no": "Resultat"
+      }
+    },
+    {
+      "name": "previous_result",
+      "type": "boolean",
+      "title": {
+        "en": "Previous result",
+        "no": "Forrige resultat"
+      }
+    }
+  ]
+}

--- a/no.tiwas.booleantoolbox/.homeycompose/flow/triggers/formula_changed_to_false.json
+++ b/no.tiwas.booleantoolbox/.homeycompose/flow/triggers/formula_changed_to_false.json
@@ -1,0 +1,53 @@
+{
+  "id": "formula_changed_to_false",
+  "deprecated": true,
+  "title": {
+    "en": "Formula result changed to FALSE",
+    "no": "Formelresultat ble USANN"
+  },
+  "titleFormatted": {
+    "en": "Formula [[formula]] changed to FALSE",
+    "no": "Formel [[formula]] ble USANN"
+  },
+  "hint": {
+    "en": "Deprecated: use 'Formula changed to...' instead.",
+    "no": "Utgått: bruk «Formel endret til...» i stedet."
+  },
+  "args": [
+    {
+      "type": "device",
+      "name": "device",
+      "filter": "driver_id=logic-unit|logic-unit-2|logic-unit-3|logic-unit-4|logic-unit-5|logic-unit-6|logic-unit-7|logic-unit-8|logic-unit-9|logic-unit-10"
+    },
+    {
+      "type": "autocomplete",
+      "name": "formula",
+      "title": {
+        "en": "Formula",
+        "no": "Formel"
+      },
+      "placeholder": {
+        "en": "Select a formula...",
+        "no": "Velg en formel..."
+      }
+    }
+  ],
+  "tokens": [
+    {
+      "name": "device_name",
+      "type": "string",
+      "title": {
+        "en": "Device name",
+        "no": "Enhetsnavn"
+      }
+    },
+    {
+      "name": "formula_name",
+      "type": "string",
+      "title": {
+        "en": "Formula name",
+        "no": "Formelnavn"
+      }
+    }
+  ]
+}

--- a/no.tiwas.booleantoolbox/.homeycompose/flow/triggers/formula_changed_to_false_lu_deprecated.json
+++ b/no.tiwas.booleantoolbox/.homeycompose/flow/triggers/formula_changed_to_false_lu_deprecated.json
@@ -47,7 +47,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=logic-unit"
+      "filter": "driver_id=logic-unit|logic-unit-2|logic-unit-3|logic-unit-4|logic-unit-5|logic-unit-6|logic-unit-7|logic-unit-8|logic-unit-9|logic-unit-10"
     },
     {
       "name": "formula",

--- a/no.tiwas.booleantoolbox/.homeycompose/flow/triggers/formula_changed_to_lu.json
+++ b/no.tiwas.booleantoolbox/.homeycompose/flow/triggers/formula_changed_to_lu.json
@@ -46,7 +46,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=logic-unit"
+      "filter": "driver_id=logic-unit|logic-unit-2|logic-unit-3|logic-unit-4|logic-unit-5|logic-unit-6|logic-unit-7|logic-unit-8|logic-unit-9|logic-unit-10"
     },
     {
       "name": "formula",
@@ -188,6 +188,14 @@
         "pl": "Wynik",
         "ru": "Результат",
         "ko": "결과"
+      }
+    },
+    {
+      "name": "previous_result",
+      "type": "boolean",
+      "title": {
+        "en": "Previous result",
+        "no": "Forrige resultat"
       }
     }
   ]

--- a/no.tiwas.booleantoolbox/.homeycompose/flow/triggers/formula_changed_to_true.json
+++ b/no.tiwas.booleantoolbox/.homeycompose/flow/triggers/formula_changed_to_true.json
@@ -1,0 +1,53 @@
+{
+  "id": "formula_changed_to_true",
+  "deprecated": true,
+  "title": {
+    "en": "Formula result changed to TRUE",
+    "no": "Formelresultat ble SANN"
+  },
+  "titleFormatted": {
+    "en": "Formula [[formula]] changed to TRUE",
+    "no": "Formel [[formula]] ble SANN"
+  },
+  "hint": {
+    "en": "Deprecated: use 'Formula changed to...' instead.",
+    "no": "Utgått: bruk «Formel endret til...» i stedet."
+  },
+  "args": [
+    {
+      "type": "device",
+      "name": "device",
+      "filter": "driver_id=logic-unit|logic-unit-2|logic-unit-3|logic-unit-4|logic-unit-5|logic-unit-6|logic-unit-7|logic-unit-8|logic-unit-9|logic-unit-10"
+    },
+    {
+      "type": "autocomplete",
+      "name": "formula",
+      "title": {
+        "en": "Formula",
+        "no": "Formel"
+      },
+      "placeholder": {
+        "en": "Select a formula...",
+        "no": "Velg en formel..."
+      }
+    }
+  ],
+  "tokens": [
+    {
+      "name": "device_name",
+      "type": "string",
+      "title": {
+        "en": "Device name",
+        "no": "Enhetsnavn"
+      }
+    },
+    {
+      "name": "formula_name",
+      "type": "string",
+      "title": {
+        "en": "Formula name",
+        "no": "Formelnavn"
+      }
+    }
+  ]
+}

--- a/no.tiwas.booleantoolbox/.homeycompose/flow/triggers/formula_changed_to_true_lu_deprecated.json
+++ b/no.tiwas.booleantoolbox/.homeycompose/flow/triggers/formula_changed_to_true_lu_deprecated.json
@@ -47,7 +47,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=logic-unit"
+      "filter": "driver_id=logic-unit|logic-unit-2|logic-unit-3|logic-unit-4|logic-unit-5|logic-unit-6|logic-unit-7|logic-unit-8|logic-unit-9|logic-unit-10"
     },
     {
       "name": "formula",

--- a/no.tiwas.booleantoolbox/LogicUnit.test.js
+++ b/no.tiwas.booleantoolbox/LogicUnit.test.js
@@ -1,0 +1,183 @@
+"use strict";
+
+jest.mock("homey", () => ({
+  Device: class {},
+  Driver: class {},
+}), { virtual: true });
+
+const FormulaEvaluator = require("./lib/FormulaEvaluator");
+const LogicUnitDevice = require("./drivers/logic-unit/device");
+const BaseLogicDriver = require("./lib/BaseLogicDriver");
+
+function createLogger() {
+  return {
+    debug: jest.fn(),
+    error: jest.fn(),
+    flow: jest.fn(),
+    formula: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  };
+}
+
+function createTriggerCard() {
+  return {
+    registerArgumentAutocompleteListener: jest.fn(),
+    registerRunListener: jest.fn(),
+    trigger: jest.fn(async () => {}),
+  };
+}
+
+function createLogicUnit(formulas) {
+  const device = Object.create(LogicUnitDevice.prototype);
+  const capabilityValues = new Map([
+    ["alarm_generic", false],
+    ["onoff", true],
+  ]);
+  const triggerCards = new Map([
+    ["formula_changed_lu", createTriggerCard()],
+    ["formula_changed_to_lu", createTriggerCard()],
+    ["formula_changed_to_true", createTriggerCard()],
+    ["formula_changed_to_false", createTriggerCard()],
+    ["formula_changed_to_true_lu_deprecated", createTriggerCard()],
+    ["formula_changed_to_false_lu_deprecated", createTriggerCard()],
+  ]);
+
+  device.logger = createLogger();
+  device.driver = { id: "logic-unit" };
+  device.formulaEvaluator = new FormulaEvaluator();
+  device.numInputs = 2;
+  device.availableInputs = ["a", "b"];
+  device.formulas = formulas;
+  device.homey = {
+    flow: {
+      getDeviceTriggerCard: jest.fn(cardId => triggerCards.get(cardId)),
+    },
+  };
+  device.getName = jest.fn(() => "Motion Formula");
+  device.hasCapability = jest.fn(capabilityId => capabilityValues.has(capabilityId));
+  device.getCapabilityValue = jest.fn(capabilityId => capabilityValues.get(capabilityId));
+  device.setCapabilityValue = jest.fn(async (capabilityId, value) => {
+    capabilityValues.set(capabilityId, value);
+  });
+  device.capabilityValues = capabilityValues;
+  device.triggerCards = triggerCards;
+  return device;
+}
+
+function createFormula(overrides = {}) {
+  return {
+    id: "f1",
+    name: "My Formula",
+    expression: "A+B",
+    enabled: true,
+    firstImpression: false,
+    inputStates: { a: "undefined", b: "undefined" },
+    lockedInputs: { a: false, b: false },
+    lastInputTime: null,
+    result: null,
+    timedOut: false,
+    sessionComplete: false,
+    ...overrides,
+  };
+}
+
+describe("Logic Unit formula results", () => {
+  test("syncs A+B to alarm_generic and fires both formula-change cards", async () => {
+    const device = createLogicUnit([createFormula()]);
+
+    await device.setInputForFormula("f1", "a", true);
+    expect(device.capabilityValues.get("alarm_generic")).toBe(false);
+
+    await device.setInputForFormula("f1", "b", false);
+    expect(device.getFormulaResult("f1")).toBe(true);
+    expect(device.capabilityValues.get("alarm_generic")).toBe(true);
+    expect(device.triggerCards.get("formula_changed_lu").trigger).not.toHaveBeenCalled();
+
+    await device.setInputForFormula("f1", "a", false);
+    expect(device.getFormulaResult("f1")).toBe(false);
+    expect(device.capabilityValues.get("alarm_generic")).toBe(false);
+    expect(device.triggerCards.get("formula_changed_lu").trigger).toHaveBeenCalledWith(
+      device,
+      {
+        device_name: "Motion Formula",
+        formula_name: "My Formula",
+        result: false,
+        previous_result: true,
+      },
+      {
+        formula_id: "f1",
+        result: false,
+        previous_result: true,
+      },
+    );
+    expect(device.triggerCards.get("formula_changed_to_lu").trigger)
+      .toHaveBeenCalledTimes(1);
+    expect(device.triggerCards.get("formula_changed_to_false").trigger)
+      .toHaveBeenCalledTimes(1);
+  });
+
+  test("keeps the aggregate alarm on while any enabled formula is true", async () => {
+    const device = createLogicUnit([
+      createFormula({ id: "f1", name: "First", expression: "A" }),
+      createFormula({ id: "f2", name: "Second", expression: "B" }),
+    ]);
+
+    await device.setInputForFormula("f1", "a", true);
+    await device.setInputForFormula("f2", "b", false);
+    expect(device.capabilityValues.get("alarm_generic")).toBe(true);
+
+    await device.setInputForFormula("f1", "a", false);
+    expect(device.capabilityValues.get("alarm_generic")).toBe(false);
+  });
+});
+
+describe("Logic Unit formula Flow cards", () => {
+  test("registers device triggers and filters by formula and result", async () => {
+    const cards = new Map();
+    const getCard = (id) => {
+      if (!cards.has(id)) cards.set(id, createTriggerCard());
+      return cards.get(id);
+    };
+    const driver = Object.create(BaseLogicDriver.prototype);
+    driver.id = "logic-unit";
+    driver.logger = createLogger();
+    driver.homey = {
+      __: key => key,
+      flow: {
+        getActionCard: jest.fn(getCard),
+        getConditionCard: jest.fn(getCard),
+        getDeviceTriggerCard: jest.fn(getCard),
+        getTriggerCard: jest.fn(getCard),
+      },
+    };
+
+    await driver.registerFlowCards();
+
+    const changedListener = cards.get("formula_changed_lu")
+      .registerRunListener.mock.calls[0][0];
+    const changedToListener = cards.get("formula_changed_to_lu")
+      .registerRunListener.mock.calls[0][0];
+
+    await expect(changedListener(
+      { formula: { id: "f1" } },
+      { formula_id: "f1", result: true },
+    )).resolves.toBe(true);
+    await expect(changedListener(
+      { formula: { id: "f2" } },
+      { formula_id: "f1", result: true },
+    )).resolves.toBe(false);
+    await expect(changedToListener(
+      { formula: { id: "f1" }, result: "true" },
+      { formula_id: "f1", result: true },
+    )).resolves.toBe(true);
+    await expect(changedToListener(
+      { formula: { id: "f1" }, result: { id: "false" } },
+      { formula_id: "f1", result: true },
+    )).resolves.toBe(false);
+    expect(driver.homey.flow.getDeviceTriggerCard)
+      .toHaveBeenCalledWith("formula_changed_lu");
+    expect(driver.homey.flow.getDeviceTriggerCard)
+      .toHaveBeenCalledWith("formula_changed_to_lu");
+  });
+});

--- a/no.tiwas.booleantoolbox/README.txt
+++ b/no.tiwas.booleantoolbox/README.txt
@@ -27,6 +27,7 @@ Logic Unit (Dynamic)
   - Define formulas such as: (A AND B) OR (NOT C)
   - Multiple formulas per unit, individual timeouts, and first-impression mode
   - Dynamic input linking, validation, and error reporting
+  - Formula result alarm plus Formula changed / Formula changed to Flow triggers
 
 State Capture Device
   Dynamically capture and restore device states at runtime.

--- a/no.tiwas.booleantoolbox/drivers/logic-unit-10/driver.compose.json
+++ b/no.tiwas.booleantoolbox/drivers/logic-unit-10/driver.compose.json
@@ -76,11 +76,27 @@
   "flow": [
     {
       "type": "trigger",
-      "id": "formula_changed_to_false_lu"
+      "id": "formula_changed_lu"
     },
     {
       "type": "trigger",
-      "id": "formula_changed_to_true_lu"
+      "id": "formula_changed_to_lu"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_false"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_true"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_false_lu_deprecated"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_true_lu_deprecated"
     },
     {
       "type": "trigger",

--- a/no.tiwas.booleantoolbox/drivers/logic-unit-2/driver.compose.json
+++ b/no.tiwas.booleantoolbox/drivers/logic-unit-2/driver.compose.json
@@ -76,11 +76,27 @@
   "flow": [
     {
       "type": "trigger",
-      "id": "formula_changed_to_false_lu"
+      "id": "formula_changed_lu"
     },
     {
       "type": "trigger",
-      "id": "formula_changed_to_true_lu"
+      "id": "formula_changed_to_lu"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_false"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_true"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_false_lu_deprecated"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_true_lu_deprecated"
     },
     {
       "type": "trigger",

--- a/no.tiwas.booleantoolbox/drivers/logic-unit-3/driver.compose.json
+++ b/no.tiwas.booleantoolbox/drivers/logic-unit-3/driver.compose.json
@@ -76,11 +76,27 @@
   "flow": [
     {
       "type": "trigger",
-      "id": "formula_changed_to_false_lu"
+      "id": "formula_changed_lu"
     },
     {
       "type": "trigger",
-      "id": "formula_changed_to_true_lu"
+      "id": "formula_changed_to_lu"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_false"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_true"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_false_lu_deprecated"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_true_lu_deprecated"
     },
     {
       "type": "trigger",

--- a/no.tiwas.booleantoolbox/drivers/logic-unit-4/driver.compose.json
+++ b/no.tiwas.booleantoolbox/drivers/logic-unit-4/driver.compose.json
@@ -76,11 +76,27 @@
   "flow": [
     {
       "type": "trigger",
-      "id": "formula_changed_to_false_lu"
+      "id": "formula_changed_lu"
     },
     {
       "type": "trigger",
-      "id": "formula_changed_to_true_lu"
+      "id": "formula_changed_to_lu"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_false"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_true"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_false_lu_deprecated"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_true_lu_deprecated"
     },
     {
       "type": "trigger",

--- a/no.tiwas.booleantoolbox/drivers/logic-unit-5/driver.compose.json
+++ b/no.tiwas.booleantoolbox/drivers/logic-unit-5/driver.compose.json
@@ -76,11 +76,27 @@
   "flow": [
     {
       "type": "trigger",
-      "id": "formula_changed_to_false_lu"
+      "id": "formula_changed_lu"
     },
     {
       "type": "trigger",
-      "id": "formula_changed_to_true_lu"
+      "id": "formula_changed_to_lu"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_false"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_true"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_false_lu_deprecated"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_true_lu_deprecated"
     },
     {
       "type": "trigger",

--- a/no.tiwas.booleantoolbox/drivers/logic-unit-6/driver.compose.json
+++ b/no.tiwas.booleantoolbox/drivers/logic-unit-6/driver.compose.json
@@ -76,11 +76,27 @@
   "flow": [
     {
       "type": "trigger",
-      "id": "formula_changed_to_false_lu"
+      "id": "formula_changed_lu"
     },
     {
       "type": "trigger",
-      "id": "formula_changed_to_true_lu"
+      "id": "formula_changed_to_lu"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_false"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_true"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_false_lu_deprecated"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_true_lu_deprecated"
     },
     {
       "type": "trigger",

--- a/no.tiwas.booleantoolbox/drivers/logic-unit-7/driver.compose.json
+++ b/no.tiwas.booleantoolbox/drivers/logic-unit-7/driver.compose.json
@@ -76,11 +76,27 @@
   "flow": [
     {
       "type": "trigger",
-      "id": "formula_changed_to_false_lu"
+      "id": "formula_changed_lu"
     },
     {
       "type": "trigger",
-      "id": "formula_changed_to_true_lu"
+      "id": "formula_changed_to_lu"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_false"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_true"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_false_lu_deprecated"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_true_lu_deprecated"
     },
     {
       "type": "trigger",

--- a/no.tiwas.booleantoolbox/drivers/logic-unit-8/driver.compose.json
+++ b/no.tiwas.booleantoolbox/drivers/logic-unit-8/driver.compose.json
@@ -76,11 +76,27 @@
   "flow": [
     {
       "type": "trigger",
-      "id": "formula_changed_to_false_lu"
+      "id": "formula_changed_lu"
     },
     {
       "type": "trigger",
-      "id": "formula_changed_to_true_lu"
+      "id": "formula_changed_to_lu"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_false"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_true"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_false_lu_deprecated"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_true_lu_deprecated"
     },
     {
       "type": "trigger",

--- a/no.tiwas.booleantoolbox/drivers/logic-unit-9/driver.compose.json
+++ b/no.tiwas.booleantoolbox/drivers/logic-unit-9/driver.compose.json
@@ -76,11 +76,27 @@
   "flow": [
     {
       "type": "trigger",
-      "id": "formula_changed_to_false_lu"
+      "id": "formula_changed_lu"
     },
     {
       "type": "trigger",
-      "id": "formula_changed_to_true_lu"
+      "id": "formula_changed_to_lu"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_false"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_true"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_false_lu_deprecated"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_true_lu_deprecated"
     },
     {
       "type": "trigger",

--- a/no.tiwas.booleantoolbox/drivers/logic-unit/driver.compose.json
+++ b/no.tiwas.booleantoolbox/drivers/logic-unit/driver.compose.json
@@ -19,6 +19,15 @@
     "alarm_config"
   ],
   "capabilitiesOptions": {
+    "alarm_generic": {
+      "title": {
+        "en": "Formula result",
+        "no": "Formelresultat"
+      },
+      "uiComponent": "sensor",
+      "getable": true,
+      "setable": false
+    },
     "alarm_config": {
       "title": {
         "en": "Configuration Error",
@@ -97,11 +106,27 @@
   "flow": [
     {
       "type": "trigger",
-      "id": "formula_changed_to_false_lu"
+      "id": "formula_changed_lu"
     },
     {
       "type": "trigger",
-      "id": "formula_changed_to_true_lu"
+      "id": "formula_changed_to_lu"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_false"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_true"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_false_lu_deprecated"
+    },
+    {
+      "type": "trigger",
+      "id": "formula_changed_to_true_lu_deprecated"
     },
     {
       "type": "trigger",

--- a/no.tiwas.booleantoolbox/lib/BaseLogicDriver.js
+++ b/no.tiwas.booleantoolbox/lib/BaseLogicDriver.js
@@ -187,20 +187,23 @@ class BaseLogicDriver extends Homey.Driver {
     async registerFlowCards() {
         this.logger.debug("driver.registering_flow_cards");
 
+        const formulaMatches = (args, state) =>
+            !!args?.formula?.id && args.formula.id === state?.formula_id;
+
+        const selectedResult = (resultArg) => {
+            const value = typeof resultArg === "object"
+                ? resultArg?.id
+                : resultArg;
+            return String(value) === "true";
+        };
+
         // ===== DEPRECATED TRIGGERS (for backward compatibility) =====
         
         // Deprecated: Formula changed to FALSE (old separate card)
         try {
-            const formulaChangedToFalseCard = this.homey.flow.getTriggerCard("formula_changed_to_false_lu_deprecated");
+            const formulaChangedToFalseCard = this.homey.flow.getDeviceTriggerCard("formula_changed_to_false_lu_deprecated");
             formulaChangedToFalseCard.registerRunListener(async (args, state) => {
-                return (
-                    args &&
-                    args.device &&
-                    args.device.driver &&
-                    args.device.driver.id &&
-                    args.device.driver.id.startsWith("logic-unit-") &&
-                    state?.result === false
-                );
+                return formulaMatches(args, state) && state?.result === false;
             });
             this.registerAutocomplete(formulaChangedToFalseCard, "formula", formulaAutocompleteHelper);
             this.logger.debug(` -> OK: DEPRECATED TRIGGER registered: 'formula_changed_to_false_lu_deprecated'`);
@@ -210,16 +213,9 @@ class BaseLogicDriver extends Homey.Driver {
 
         // Deprecated: Formula changed to TRUE (old separate card)
         try {
-            const formulaChangedToTrueCard = this.homey.flow.getTriggerCard("formula_changed_to_true_lu_deprecated");
+            const formulaChangedToTrueCard = this.homey.flow.getDeviceTriggerCard("formula_changed_to_true_lu_deprecated");
             formulaChangedToTrueCard.registerRunListener(async (args, state) => {
-                return (
-                    args &&
-                    args.device &&
-                    args.device.driver &&
-                    args.device.driver.id &&
-                    args.device.driver.id.startsWith("logic-unit-") &&
-                    state?.result === true
-                );
+                return formulaMatches(args, state) && state?.result === true;
             });
             this.registerAutocomplete(formulaChangedToTrueCard, "formula", formulaAutocompleteHelper);
             this.logger.debug(` -> OK: DEPRECATED TRIGGER registered: 'formula_changed_to_true_lu_deprecated'`);
@@ -228,22 +224,41 @@ class BaseLogicDriver extends Homey.Driver {
         }
 
         // ===== NEW IMPROVED TRIGGERS =====
-        
-        // New: Formula changed to [dropdown selection] (combined card)
-        const formulaChangedToCard = this.homey.flow.getTriggerCard("formula_changed_to_lu");
+
+        // Formula changed (any TRUE/FALSE transition)
+        const formulaChangedCard = this.homey.flow.getDeviceTriggerCard("formula_changed_lu");
+        formulaChangedCard.registerRunListener(async (args, state) => {
+            return formulaMatches(args, state);
+        });
+        this.registerAutocomplete(formulaChangedCard, "formula", formulaAutocompleteHelper);
+        this.logger.debug(` -> OK: TRIGGER registered: 'formula_changed_lu'`);
+
+        // Formula changed to [dropdown selection]
+        const formulaChangedToCard = this.homey.flow.getDeviceTriggerCard("formula_changed_to_lu");
         formulaChangedToCard.registerRunListener(async (args, state) => {
-            const expectedResult = args.result === "true";
-            return (
-                args &&
-                args.device &&
-                args.device.driver &&
-                args.device.driver.id &&
-                args.device.driver.id.startsWith("logic-unit-") &&
-                state?.result === expectedResult
-            );
+            return formulaMatches(args, state)
+                && state?.result === selectedResult(args?.result);
         });
         this.registerAutocomplete(formulaChangedToCard, "formula", formulaAutocompleteHelper);
-        this.logger.debug(` -> OK: NEW TRIGGER registered: 'formula_changed_to_lu'`);
+        this.logger.debug(` -> OK: TRIGGER registered: 'formula_changed_to_lu'`);
+
+        // Original pre-Compose cards retained for existing flows.
+        const legacyFormulaCards = [
+            { id: "formula_changed_to_true", result: true },
+            { id: "formula_changed_to_false", result: false },
+        ];
+        legacyFormulaCards.forEach((cardInfo) => {
+            try {
+                const card = this.homey.flow.getDeviceTriggerCard(cardInfo.id);
+                card.registerRunListener(async (args, state) =>
+                    formulaMatches(args, state) && state?.result === cardInfo.result,
+                );
+                this.registerAutocomplete(card, "formula", formulaAutocompleteHelper);
+                this.logger.debug(` -> OK: LEGACY TRIGGER registered: '${cardInfo.id}'`);
+            } catch (e) {
+                this.logger.warn(` -> SKIP: Legacy trigger '${cardInfo.id}' not found`);
+            }
+        });
 
         // ===== EXISTING TRIGGERS (unchanged) =====
         

--- a/no.tiwas.booleantoolbox/lib/BaseLogicUnit.js
+++ b/no.tiwas.booleantoolbox/lib/BaseLogicUnit.js
@@ -114,6 +114,80 @@ module.exports = class BaseLogicUnit extends Homey.Device {
   }
 
   /**
+   * Synchronize the Logic Unit's generic alarm with its aggregate result.
+   * The alarm is active whenever at least one enabled formula is TRUE.
+   *
+   * @returns {Promise<boolean>} The aggregate alarm state.
+   */
+  async syncOverallAlarmState() {
+    const overallState = this.formulas.some(
+      (formula) => formula.enabled && formula.result === true,
+    );
+    if (!this.hasCapability("alarm_generic")) {
+      return overallState;
+    }
+    const currentState = this.getCapabilityValue("alarm_generic");
+
+    if (currentState !== overallState) {
+      await this.safeSetCapabilityValue("alarm_generic", overallState);
+      this.logger.info("Overall Logic Unit alarm updated", {
+        alarmState: overallState,
+      });
+    }
+
+    return overallState;
+  }
+
+  /**
+   * Fire the current formula-change cards plus the legacy TRUE/FALSE cards.
+   *
+   * @param {Object} formula - Formula whose result changed.
+   * @param {boolean} previousResult - Previous boolean result.
+   * @param {boolean} result - New boolean result.
+   * @returns {Promise<void>}
+   */
+  async triggerFormulaChanged(formula, previousResult, result) {
+    const tokens = {
+      device_name: this.getName(),
+      formula_name: formula.name,
+      result,
+      previous_result: previousResult,
+    };
+    const state = {
+      formula_id: formula.id,
+      result,
+      previous_result: previousResult,
+    };
+    const legacyTokens = {
+      device_name: tokens.device_name,
+      formula_name: tokens.formula_name,
+    };
+    const cards = [
+      { id: "formula_changed_lu", tokens },
+      { id: "formula_changed_to_lu", tokens },
+      {
+        id: result ? "formula_changed_to_true" : "formula_changed_to_false",
+        tokens: legacyTokens,
+      },
+      {
+        id: result
+          ? "formula_changed_to_true_lu_deprecated"
+          : "formula_changed_to_false_lu_deprecated",
+        tokens: legacyTokens,
+      },
+    ];
+
+    for (const cardInfo of cards) {
+      try {
+        const card = this.homey.flow.getDeviceTriggerCard(cardInfo.id);
+        await card.trigger(this, cardInfo.tokens, state);
+      } catch (e) {
+        this.logger.error(`Failed to trigger '${cardInfo.id}'`, e);
+      }
+    }
+  }
+
+  /**
    * Initializes the Logic Unit device when added or app starts.
    *
    * Performs:
@@ -161,6 +235,9 @@ module.exports = class BaseLogicUnit extends Homey.Device {
       );
     }
     if (!this.hasCapability("alarm_generic")) {
+      await this.addCapability("alarm_generic").catch((e) =>
+        this.logger.error("Failed to add 'alarm_generic' capability", e),
+      );
     }
 
     // ✅ STEP 2: Add alarm_config capability if missing
@@ -1322,35 +1399,13 @@ module.exports = class BaseLogicUnit extends Homey.Device {
       formula.result = result;
       formula.timedOut = false;
 
+      await this.syncOverallAlarmState();
+
       if (result !== previous && previous !== null) {
-        const triggerData = {
-          formula: {
-            id: formula.id,
-            name: formula.name,
-          },
-        };
-        const state = {
-          formulaId: formula.id,
-        };
-        const triggerCardId = result
-          ? "formula_changed_to_true"
-          : "formula_changed_to_false";
-        try {
-          this.logger.flow(
-            `Triggering flow '${triggerCardId}' for '${formula.name}'`,
-          );
-          const card = this.homey.flow.getDeviceTriggerCard(triggerCardId);
-          await card.trigger(this, triggerData, state);
-        } catch (e) {
-          if (e.message && e.message.includes("Invalid Flow Card ID")) {
-            this.logger.error(
-              `FATAL: Trigger card '${triggerCardId}' not found. Check app.json/compose flow definitions.`,
-              e,
-            );
-          } else {
-            this.logger.error("flow.trigger_error", e);
-          }
-        }
+        this.logger.flow(
+          `Triggering formula change flows for '${formula.name}'`,
+        );
+        await this.triggerFormulaChanged(formula, previous, result);
       }
       return result;
     } catch (e) {
@@ -1393,10 +1448,7 @@ module.exports = class BaseLogicUnit extends Homey.Device {
         formula.result = null;
       }
     }
-    // ✅ Calculate overall state (TRUE if any formula is TRUE)
-    const overallDeviceState = this.formulas.some(
-      (f) => f.enabled && f.result === true,
-    );
+    await this.syncOverallAlarmState();
 
     this.logger.debug("formula.evaluated_count", {
       count: results.length,
@@ -1460,6 +1512,8 @@ module.exports = class BaseLogicUnit extends Homey.Device {
     this.logger.info(
       `Initial evaluation complete. Final state: ${finalState} (anyEvaluated=${anyEvaluated})`,
     );
+
+    await this.syncOverallAlarmState();
 
     if (
       !anyEvaluated &&

--- a/no.tiwas.booleantoolbox/package-lock.json
+++ b/no.tiwas.booleantoolbox/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "no.tiwas.booleantoolbox",
-  "version": "1.10.22",
+  "version": "1.10.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "no.tiwas.booleantoolbox",
-      "version": "1.10.22",
+      "version": "1.10.23",
       "license": "ISC",
       "dependencies": {
         "homey-api": "^3.17.0",

--- a/no.tiwas.booleantoolbox/package.json
+++ b/no.tiwas.booleantoolbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "no.tiwas.booleantoolbox",
-  "version": "1.10.22",
+  "version": "1.10.23",
   "main": "app.js",
   "dependencies": {
     "homey-api": "^3.17.0",


### PR DESCRIPTION
## Summary
- restore the Logic Unit aggregate Formula result alarm so Homey's generic alarm triggers work again
- add Formula changed and fix Formula changed to... with formula/result filtering and current/previous result tags
- retain legacy trigger IDs, add regression coverage, and release documentation for v1.10.23

## Verification
- npm test -- --runInBand: 8 suites, 139 tests passed
- homey app validate: publish-level validation passed
- Homey Build 52 published to the test channel as v1.10.23
- homey app install succeeded on Lars's New Homey
- Homey Community topic updated and verified
