### PR TITLE
Fix capability instance cleanup

### DIFF
--- a/no.tiwas.booleantoolbox/CircadianLightGroupDevice.test.js
+++ b/no.tiwas.booleantoolbox/CircadianLightGroupDevice.test.js
@@ -780,3 +780,46 @@ describe('CircadianLightGroupDevice pause persistence', () => {
     }));
   });
 });
+
+describe('CircadianLightGroupDevice capability watcher cleanup', () => {
+  test('destroys the lux capability instance during watcher teardown', async () => {
+    const device = createDeviceHarness();
+    const instance = { destroy: jest.fn() };
+    const apiDevice = {
+      capabilitiesObj: { measure_luminance: { value: 42 } },
+      makeCapabilityInstance: jest.fn(() => instance),
+    };
+    device.luxWatchers = new Map();
+    device.getConfig = jest.fn(() => ({
+      profile: { anchors: { day: { mode: 'lux', sensorDeviceId: 'sensor-1' } } },
+    }));
+    device.homey = { app: { api: { devices: { getDevice: jest.fn().mockResolvedValue(apiDevice) } } } };
+    device.onLuxSensorValue = jest.fn().mockResolvedValue(undefined);
+    device.error = jest.fn();
+
+    await device.setupLuxWatchers();
+    await device.teardownLuxWatchers();
+
+    expect(apiDevice.makeCapabilityInstance).toHaveBeenCalledWith('measure_luminance', expect.any(Function));
+    expect(instance.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  test('destroys the member on/off capability instance during watcher teardown', async () => {
+    const device = createDeviceHarness();
+    const instance = { destroy: jest.fn() };
+    const apiDevice = {
+      capabilitiesObj: { onoff: { value: false, setable: true } },
+      makeCapabilityInstance: jest.fn(() => instance),
+    };
+    device.memberOnoffWatchers = new Map();
+    device.getConfig = jest.fn(() => ({ devices: [{ id: 'light-1', name: 'Kitchen' }] }));
+    device.homey = { app: { api: { devices: { getDevice: jest.fn().mockResolvedValue(apiDevice) } } } };
+    device.onMemberOnoffChange = jest.fn().mockResolvedValue(undefined);
+
+    await device.setupMemberOnoffWatchers();
+    await device.teardownMemberOnoffWatchers();
+
+    expect(apiDevice.makeCapabilityInstance).toHaveBeenCalledWith('onoff', expect.any(Function));
+    expect(instance.destroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/no.tiwas.booleantoolbox/CircadianLightGroupDriver.test.js
+++ b/no.tiwas.booleantoolbox/CircadianLightGroupDriver.test.js
@@ -1,0 +1,34 @@
+jest.mock('homey', () => ({
+  Driver: class {},
+}), { virtual: true });
+
+jest.mock('suncalc', () => ({}), { virtual: true });
+
+const CircadianLightGroupDriver = require('./drivers/circadian-light-group/driver');
+
+describe('CircadianLightGroupDriver probe cleanup', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('destroys all capability instances after completing a pairing probe', async () => {
+    jest.useFakeTimers();
+    const instance = { destroy: jest.fn() };
+    const apiDevice = {
+      capabilitiesObj: { onoff: { value: false, setable: true } },
+      makeCapabilityInstance: jest.fn(() => instance),
+      setCapabilityValue: jest.fn().mockResolvedValue(undefined),
+    };
+    const driver = Object.create(CircadianLightGroupDriver.prototype);
+    driver.homey = { app: { api: { devices: { getDevice: jest.fn().mockResolvedValue(apiDevice) } } } };
+    driver.debug = jest.fn();
+    driver.error = jest.fn();
+
+    const probe = driver.probeDevice('light-1');
+    await jest.runAllTimersAsync();
+    await probe;
+
+    expect(apiDevice.makeCapabilityInstance).toHaveBeenCalledWith('onoff', expect.any(Function));
+    expect(instance.destroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/no.tiwas.booleantoolbox/WaiterManager.test.js
+++ b/no.tiwas.booleantoolbox/WaiterManager.test.js
@@ -1,0 +1,106 @@
+const WaiterManager = require('./lib/WaiterManager');
+
+function createLogger() {
+  return {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+}
+
+describe('WaiterManager capability listener cleanup', () => {
+  let manager;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    WaiterManager.instance = null;
+    manager = new WaiterManager({}, createLogger());
+  });
+
+  afterEach(() => {
+    manager.destroy();
+    WaiterManager.instance = null;
+    jest.useRealTimers();
+  });
+
+  async function createDeviceWaiter(id = 'waiter-1', timeoutValue = 0) {
+    await manager.createWaiter(
+      id,
+      { timeoutValue, timeoutUnit: 'ms' },
+      { flowId: 'flow-1' },
+      { deviceId: 'device-1', capability: 'onoff', targetValue: true },
+    );
+  }
+
+  test('destroys the capability instance when a waiter is removed', async () => {
+    await createDeviceWaiter();
+    const instance = { destroy: jest.fn() };
+    const homey = { devices: { getDevice: jest.fn().mockResolvedValue({
+      makeCapabilityInstance: jest.fn().mockResolvedValue(instance),
+    }) } };
+
+    await manager.registerCapabilityListener('waiter-1', homey);
+    manager.removeWaiter('waiter-1');
+
+    expect(instance.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  test('destroys the capability instance when a waiter times out', async () => {
+    await createDeviceWaiter('waiter-timeout', 100);
+    const instance = { destroy: jest.fn() };
+    const homey = { devices: { getDevice: jest.fn().mockResolvedValue({
+      makeCapabilityInstance: jest.fn().mockResolvedValue(instance),
+    }) } };
+
+    await manager.registerCapabilityListener('waiter-timeout', homey);
+    await jest.advanceTimersByTimeAsync(100);
+
+    expect(instance.destroy).toHaveBeenCalledTimes(1);
+    expect(manager.waiters.has('waiter-timeout')).toBe(false);
+  });
+
+  test('destroys active capability instances when the manager is shut down', async () => {
+    await createDeviceWaiter();
+    const instance = { destroy: jest.fn() };
+    const homey = { devices: { getDevice: jest.fn().mockResolvedValue({
+      makeCapabilityInstance: jest.fn().mockResolvedValue(instance),
+    }) } };
+
+    await manager.registerCapabilityListener('waiter-1', homey);
+    manager.destroy();
+
+    expect(instance.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  test('destroys a late capability instance if its waiter was removed during registration', async () => {
+    await createDeviceWaiter();
+    let resolveInstance;
+    const instancePromise = new Promise(resolve => { resolveInstance = resolve; });
+    const instance = { destroy: jest.fn() };
+    const homey = { devices: { getDevice: jest.fn().mockResolvedValue({
+      makeCapabilityInstance: jest.fn().mockReturnValue(instancePromise),
+    }) } };
+
+    const registration = manager.registerCapabilityListener('waiter-1', homey);
+    await Promise.resolve();
+    manager.removeWaiter('waiter-1');
+    resolveInstance(instance);
+    await registration;
+
+    expect(instance.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  test('reinitializing a waiter releases its previous capability instance', async () => {
+    await createDeviceWaiter();
+    const instance = { destroy: jest.fn() };
+    const homey = { devices: { getDevice: jest.fn().mockResolvedValue({
+      makeCapabilityInstance: jest.fn().mockResolvedValue(instance),
+    }) } };
+    await manager.registerCapabilityListener('waiter-1', homey);
+
+    await createDeviceWaiter();
+
+    expect(instance.destroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/no.tiwas.booleantoolbox/WaiterManager.test.js
+++ b/no.tiwas.booleantoolbox/WaiterManager.test.js
@@ -103,4 +103,14 @@ describe('WaiterManager capability listener cleanup', () => {
 
     expect(instance.destroy).toHaveBeenCalledTimes(1);
   });
+
+  test('reinitializing a waiter with a wildcard in its ID only removes that exact waiter', async () => {
+    await createDeviceWaiter('job*');
+    await createDeviceWaiter('job1');
+
+    await createDeviceWaiter('job*');
+
+    expect(manager.waiters.has('job*')).toBe(true);
+    expect(manager.waiters.has('job1')).toBe(true);
+  });
 });

--- a/no.tiwas.booleantoolbox/drivers/circadian-light-group/device.js
+++ b/no.tiwas.booleantoolbox/drivers/circadian-light-group/device.js
@@ -152,7 +152,10 @@ class CircadianLightGroupDevice extends Homey.Device {
         const listener = (newValue) => {
           this.onLuxSensorValue(sensorId, Number(newValue)).catch(err => this.error('Lux watcher error:', err));
         };
-        apiDevice.makeCapabilityInstance('measure_luminance', listener);
+        watcher.capabilityInstance = apiDevice.makeCapabilityInstance(
+          'measure_luminance',
+          listener,
+        );
         watcher.listener = listener;
         watcher.apiDevice = apiDevice;
         this.debug(`Lux watcher attached to sensor ${sensorId} (initial value: ${initialValue})`);
@@ -166,8 +169,8 @@ class CircadianLightGroupDevice extends Homey.Device {
     if (!this.luxWatchers || this.luxWatchers.size === 0) return;
     for (const [, watcher] of this.luxWatchers) {
       try {
-        if (watcher.apiDevice && watcher.listener && typeof watcher.apiDevice.destroyCapabilityInstance === 'function') {
-          watcher.apiDevice.destroyCapabilityInstance('measure_luminance');
+        if (watcher.capabilityInstance && typeof watcher.capabilityInstance.destroy === 'function') {
+          watcher.capabilityInstance.destroy();
         }
       } catch (error) {
         // ignore
@@ -211,7 +214,10 @@ class CircadianLightGroupDevice extends Homey.Device {
             this.debug(`member onoff[${item.name || item.id}] handler failed: ${error.message}`);
           });
         };
-        apiDevice.makeCapabilityInstance('onoff', listener);
+        watcher.capabilityInstance = apiDevice.makeCapabilityInstance(
+          'onoff',
+          listener,
+        );
         watcher.listener = listener;
         this.memberOnoffWatchers.set(item.id, watcher);
         this.debug(`Member onoff watcher attached to ${item.name || item.id} (initial value: ${watcher.value})`);
@@ -225,8 +231,8 @@ class CircadianLightGroupDevice extends Homey.Device {
     if (!this.memberOnoffWatchers || this.memberOnoffWatchers.size === 0) return;
     for (const [, watcher] of this.memberOnoffWatchers) {
       try {
-        if (watcher.apiDevice && watcher.listener && typeof watcher.apiDevice.destroyCapabilityInstance === 'function') {
-          watcher.apiDevice.destroyCapabilityInstance('onoff');
+        if (watcher.capabilityInstance && typeof watcher.capabilityInstance.destroy === 'function') {
+          watcher.capabilityInstance.destroy();
         }
       } catch (error) {
         // ignore

--- a/no.tiwas.booleantoolbox/drivers/circadian-light-group/driver.js
+++ b/no.tiwas.booleantoolbox/drivers/circadian-light-group/driver.js
@@ -397,10 +397,10 @@ class CircadianLightGroupDriver extends Homey.Driver {
         this.error('Probe restore failed:', error);
       }
 
-      for (const capId of Object.keys(capInstances)) {
+      for (const instance of Object.values(capInstances)) {
         try {
-          if (typeof apiDevice.destroyCapabilityInstance === 'function') {
-            apiDevice.destroyCapabilityInstance(capId);
+          if (instance && typeof instance.destroy === 'function') {
+            instance.destroy();
           }
         } catch (error) { /* ignore */ }
       }

--- a/no.tiwas.booleantoolbox/lib/WaiterManager.js
+++ b/no.tiwas.booleantoolbox/lib/WaiterManager.js
@@ -58,7 +58,7 @@ class WaiterManager {
         const existing = this.waiters.get(id);
         if (existing && existing.flowId === flowContext.flowId) {
             this.logger.debug(`♻️  Re-initializing existing waiter: ${id}`);
-            this.removeWaiter(id);
+            this.removeWaiterById(id);
         } else if (existing) {
             throw new Error(`Waiter ID "${id}" already exists`);
         }
@@ -117,22 +117,27 @@ class WaiterManager {
 
     removeWaiter(idPattern) {
         const matches = this.getWaitersByPattern(idPattern);
-        for (const { id, data } of matches) {
-            if (data.timeoutHandle) clearTimeout(data.timeoutHandle);
-            if (data.capabilityListener) {
-                try { data.capabilityListener.instance?.destroy(); } catch (e) {}
-            }
-            if (data.virtualGateConfig?.gateName) {
-                const gate = this.virtualGates.get(data.virtualGateConfig.gateName);
-                if (gate) gate.waiters.delete(id);
-            }
-            if (this.flowTracking.has(data.flowId)) {
-                this.flowTracking.get(data.flowId).delete(id);
-                if (this.flowTracking.get(data.flowId).size === 0) this.flowTracking.delete(data.flowId);
-            }
-            this.waiters.delete(id);
-        }
+        for (const { id } of matches) this.removeWaiterById(id);
         return matches.length;
+    }
+
+    removeWaiterById(id) {
+        const data = this.waiters.get(id);
+        if (!data) return false;
+        if (data.timeoutHandle) clearTimeout(data.timeoutHandle);
+        if (data.capabilityListener) {
+            try { data.capabilityListener.instance?.destroy(); } catch (e) {}
+        }
+        if (data.virtualGateConfig?.gateName) {
+            const gate = this.virtualGates.get(data.virtualGateConfig.gateName);
+            if (gate) gate.waiters.delete(id);
+        }
+        if (this.flowTracking.has(data.flowId)) {
+            this.flowTracking.get(data.flowId).delete(id);
+            if (this.flowTracking.get(data.flowId).size === 0) this.flowTracking.delete(data.flowId);
+        }
+        this.waiters.delete(id);
+        return true;
     }
 
     async registerCapabilityListener(waiterId, homey) {

--- a/no.tiwas.booleantoolbox/lib/WaiterManager.js
+++ b/no.tiwas.booleantoolbox/lib/WaiterManager.js
@@ -58,7 +58,7 @@ class WaiterManager {
         const existing = this.waiters.get(id);
         if (existing && existing.flowId === flowContext.flowId) {
             this.logger.debug(`♻️  Re-initializing existing waiter: ${id}`);
-            if (existing.timeoutHandle) clearTimeout(existing.timeoutHandle);
+            this.removeWaiter(id);
         } else if (existing) {
             throw new Error(`Waiter ID "${id}" already exists`);
         }
@@ -77,7 +77,7 @@ class WaiterManager {
             config,
             deviceConfig,
             virtualGateConfig,
-            capabilityListener: null
+            capabilityListener: null,
         };
 
         this.setupTimeout(waiterData);
@@ -120,7 +120,7 @@ class WaiterManager {
         for (const { id, data } of matches) {
             if (data.timeoutHandle) clearTimeout(data.timeoutHandle);
             if (data.capabilityListener) {
-                try { data.capabilityListener.device.removeListener(`capability.${data.capabilityListener.capability}`, data.capabilityListener.listener); } catch (e) {}
+                try { data.capabilityListener.instance?.destroy(); } catch (e) {}
             }
             if (data.virtualGateConfig?.gateName) {
                 const gate = this.virtualGates.get(data.virtualGateConfig.gateName);
@@ -146,8 +146,20 @@ class WaiterManager {
                     this.removeWaiter(waiterId);
                 }
             };
-            await device.makeCapabilityInstance(waiter.deviceConfig.capability, listener);
-            waiter.capabilityListener = { device, capability: waiter.deviceConfig.capability, listener };
+            const instance = await device.makeCapabilityInstance(
+                waiter.deviceConfig.capability,
+                listener,
+            );
+            if (this.waiters.get(waiterId) !== waiter) {
+                try { instance?.destroy(); } catch (e) {}
+                return;
+            }
+            waiter.capabilityListener = {
+                device,
+                capability: waiter.deviceConfig.capability,
+                listener,
+                instance,
+            };
         } catch (error) { this.logger.error(error); throw error; }
     }
 
@@ -262,7 +274,7 @@ class WaiterManager {
 
     destroy() {
         if (this.cleanupInterval) clearInterval(this.cleanupInterval);
-        for (const [id, data] of this.waiters.entries()) { if (data.timeoutHandle) clearTimeout(data.timeoutHandle); }
+        for (const id of [...this.waiters.keys()]) this.removeWaiter(id);
         this.waiters.clear(); this.virtualGates.clear(); this.flowTracking.clear();
         this.logger.info('🛑 WaiterManager destroyed');
     }


### PR DESCRIPTION
Closes #7\n\nRetains and destroys capability instances for Circadian watchers, pairing probes, and WaiterManager lifecycle paths. Adds regression coverage for teardown, timeout, shutdown, waiter replacement, registration races, and pairing probes.\n\nValidation:\n- npm test -- --runInBand\n- homey app validate --level=publish\n- node --check for modified runtime files