### PR TITLE
Reap stale indefinite waiters

### DIFF
--- a/no.tiwas.booleantoolbox/WaiterManager.test.js
+++ b/no.tiwas.booleantoolbox/WaiterManager.test.js
@@ -193,6 +193,18 @@ describe('WaiterManager orphan cleanup', () => {
     expect(manager.waiters.has('stopped')).toBe(false);
   });
 
+  test('starts the orphan age when a timed waiter is changed to no timeout', async () => {
+    await createWaiter('changed-timeout', 1000);
+    jest.setSystemTime(Date.now() + manager.MAX_ORPHAN_AGE_MS);
+
+    expect(manager.updateWaiter('changed-timeout', { timeoutMs: 0 })).toBe(true);
+    expect(manager.cleanupOrphans()).toBe(0);
+    jest.setSystemTime(Date.now() + manager.MAX_ORPHAN_AGE_MS);
+
+    expect(manager.cleanupOrphans()).toBe(1);
+    expect(manager.waiters.has('changed-timeout')).toBe(false);
+  });
+
   test('reclaims stale indefinite waiters so the waiter limit recovers', async () => {
     for (let index = 0; index < manager.MAX_WAITERS; index++) {
       await createWaiter(`stale-${index}`);

--- a/no.tiwas.booleantoolbox/WaiterManager.test.js
+++ b/no.tiwas.booleantoolbox/WaiterManager.test.js
@@ -114,3 +114,102 @@ describe('WaiterManager capability listener cleanup', () => {
     expect(manager.waiters.has('job1')).toBe(true);
   });
 });
+
+describe('WaiterManager orphan cleanup', () => {
+  let manager;
+  let logger;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+    WaiterManager.instance = null;
+    logger = createLogger();
+    manager = new WaiterManager({}, logger);
+  });
+
+  afterEach(() => {
+    manager.destroy();
+    WaiterManager.instance = null;
+    jest.useRealTimers();
+  });
+
+  async function createWaiter(id, timeoutValue = 0, virtualGateConfig = null) {
+    await manager.createWaiter(
+      id,
+      { timeoutValue, timeoutUnit: 'ms' },
+      { flowId: `flow-${id}` },
+      null,
+      virtualGateConfig,
+    );
+  }
+
+  test('reaps an indefinite waiter after the orphan age and resolves its Flow as false', async () => {
+    await createWaiter('orphan');
+    const waiter = manager.waiters.get('orphan');
+    waiter.resolver = jest.fn();
+    jest.setSystemTime(Date.now() + manager.MAX_ORPHAN_AGE_MS);
+
+    expect(manager.cleanupOrphans()).toBe(1);
+
+    expect(waiter.resolver).toHaveBeenCalledWith(false);
+    expect(manager.waiters.has('orphan')).toBe(false);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Reaping orphan waiter "orphan"'));
+  });
+
+  test('does not reap a waiter that completed through its gate before cleanup', async () => {
+    await createWaiter('completed', 0, { gateName: 'gate-1', targetState: 'GO' });
+    const waiter = manager.waiters.get('completed');
+    waiter.resolver = jest.fn();
+
+    expect(manager.setGateState('gate-1', 'GO')).toBe(1);
+    jest.setSystemTime(Date.now() + manager.MAX_ORPHAN_AGE_MS);
+
+    expect(manager.cleanupOrphans()).toBe(0);
+    expect(waiter.resolver).toHaveBeenCalledWith({ gate_state: true, gate_state_text: 'GO' });
+    expect(manager.waiters.has('completed')).toBe(false);
+  });
+
+  test('lets timed waiters expire through their own timeout instead of orphan cleanup', async () => {
+    await createWaiter('timed', 100);
+    const waiter = manager.waiters.get('timed');
+    waiter.resolver = jest.fn();
+    jest.setSystemTime(Date.now() + manager.MAX_ORPHAN_AGE_MS);
+
+    expect(manager.cleanupOrphans()).toBe(0);
+    expect(manager.waiters.has('timed')).toBe(true);
+    await jest.advanceTimersByTimeAsync(100);
+
+    expect(waiter.resolver).toHaveBeenCalledWith(false);
+    expect(manager.waiters.has('timed')).toBe(false);
+  });
+
+  test('does not revisit a waiter that was explicitly stopped', async () => {
+    await createWaiter('stopped');
+
+    expect(manager.stopWaiter('stopped')).toBe(1);
+    jest.setSystemTime(Date.now() + manager.MAX_ORPHAN_AGE_MS);
+
+    expect(manager.cleanupOrphans()).toBe(0);
+    expect(manager.waiters.has('stopped')).toBe(false);
+  });
+
+  test('reclaims stale indefinite waiters so the waiter limit recovers', async () => {
+    for (let index = 0; index < manager.MAX_WAITERS; index++) {
+      await createWaiter(`stale-${index}`);
+    }
+    jest.setSystemTime(Date.now() + manager.MAX_ORPHAN_AGE_MS);
+
+    expect(manager.cleanupOrphans()).toBe(manager.MAX_WAITERS);
+    await expect(createWaiter('fresh')).resolves.toBeUndefined();
+    expect(manager.waiters.has('fresh')).toBe(true);
+  });
+
+  test('stops the orphan cleanup interval during shutdown', async () => {
+    const cleanupOrphans = jest.spyOn(manager, 'cleanupOrphans');
+
+    manager.destroy();
+    await jest.advanceTimersByTimeAsync(2 * 60000);
+
+    expect(cleanupOrphans).not.toHaveBeenCalled();
+  });
+});

--- a/no.tiwas.booleantoolbox/lib/WaiterManager.js
+++ b/no.tiwas.booleantoolbox/lib/WaiterManager.js
@@ -13,6 +13,9 @@ class WaiterManager {
         this.virtualGates = new Map(); // gateName -> { state, waiters: Set<waiterId> }
         this.MAX_WAITERS = 100;
         this.MAX_TIMEOUT_MS = 24 * 60 * 60 * 1000;
+        // A no-timeout waiter represents a running Flow. Keep it long enough for
+        // intentional waits, but reap it eventually if the Flow was abandoned.
+        this.MAX_ORPHAN_AGE_MS = 24 * 60 * 60 * 1000;
         this.MIN_TIMEOUT_MS = 100;
         this.WARNING_THRESHOLD = 50;
         this.cleanupInterval = setInterval(() => this.cleanupOrphans(), 60000);
@@ -275,7 +278,21 @@ class WaiterManager {
         return results.sort((a,b) => b.name.localeCompare(a.name));
     }
 
-    cleanupOrphans() { /* ... existing simplified ... */ }
+    cleanupOrphans() {
+        const now = Date.now();
+        let reaped = 0;
+        for (const [id, waiter] of this.waiters.entries()) {
+            if (waiter.timeoutMs !== 0 || now - waiter.created < this.MAX_ORPHAN_AGE_MS) continue;
+
+            this.logger.warn(`🧹 Reaping orphan waiter "${id}" after ${this.MAX_ORPHAN_AGE_MS}ms without a timeout`);
+            if (waiter.resolver) {
+                try { waiter.resolver(false); } catch (error) { this.logger.error(error); }
+            }
+            this.removeWaiterById(id);
+            reaped++;
+        }
+        return reaped;
+    }
 
     destroy() {
         if (this.cleanupInterval) clearInterval(this.cleanupInterval);

--- a/no.tiwas.booleantoolbox/lib/WaiterManager.js
+++ b/no.tiwas.booleantoolbox/lib/WaiterManager.js
@@ -75,6 +75,7 @@ class WaiterManager {
             flowToken: flowContext.flowToken,
             enabled: true,
             timeoutMs,
+            indefiniteSince: timeoutMs === 0 ? Date.now() : null,
             timeoutHandle: null,
             resolver: null,
             config,
@@ -246,7 +247,10 @@ class WaiterManager {
         if (!waiter) return false;
         
         if (updates.timeoutMs !== undefined) {
+            const wasIndefinite = waiter.timeoutMs === 0;
             waiter.timeoutMs = updates.timeoutMs;
+            if (waiter.timeoutMs === 0 && !wasIndefinite) waiter.indefiniteSince = Date.now();
+            if (waiter.timeoutMs !== 0) waiter.indefiniteSince = null;
             this.setupTimeout(waiter);
             this.logger.info(`⏱️ Updated timeout for waiter "${id}" to ${waiter.timeoutMs}ms`);
         }
@@ -282,7 +286,8 @@ class WaiterManager {
         const now = Date.now();
         let reaped = 0;
         for (const [id, waiter] of this.waiters.entries()) {
-            if (waiter.timeoutMs !== 0 || now - waiter.created < this.MAX_ORPHAN_AGE_MS) continue;
+            const indefiniteSince = waiter.indefiniteSince ?? waiter.created;
+            if (waiter.timeoutMs !== 0 || now - indefiniteSince < this.MAX_ORPHAN_AGE_MS) continue;
 
             this.logger.warn(`🧹 Reaping orphan waiter "${id}" after ${this.MAX_ORPHAN_AGE_MS}ms without a timeout`);
             if (waiter.resolver) {


### PR DESCRIPTION
Closes #8\n\nDefines a 24-hour orphan policy for waiters configured without a timeout. The periodic cleanup logs the reason, resolves an abandoned Flow as false, and removes its tracking and capability subscription.\n\nValidation:\n- npm test -- --runInBand (170 tests)\n- homey app validate --level=publish\n- node --check lib/WaiterManager.js