### PR TITLE
Add Logic Device formula timeout trigger

### DIFF
--- a/no.tiwas.booleantoolbox/.homeycompose/flow/triggers/formula_timeout_ld.json
+++ b/no.tiwas.booleantoolbox/.homeycompose/flow/triggers/formula_timeout_ld.json
@@ -1,0 +1,30 @@
+{
+  "id": "formula_timeout_ld",
+  "title": {
+    "en": "Formula timed out",
+    "no": "Formel fikk timeout"
+  },
+  "titleFormatted": {
+    "en": "Formula [[formula]] timed out",
+    "no": "Formel [[formula]] fikk timeout"
+  },
+  "args": [
+    {
+      "type": "device",
+      "name": "device",
+      "filter": "driver_id=logic-device"
+    },
+    {
+      "type": "autocomplete",
+      "name": "formula",
+      "title": {
+        "en": "Formula",
+        "no": "Formel"
+      },
+      "placeholder": {
+        "en": "Select formula",
+        "no": "Velg formel"
+      }
+    }
+  ]
+}

--- a/no.tiwas.booleantoolbox/LogicDevice.test.js
+++ b/no.tiwas.booleantoolbox/LogicDevice.test.js
@@ -154,13 +154,48 @@ describe('LogicDeviceDevice settings validation', () => {
   });
 });
 
+describe('LogicDeviceDevice formula timeouts', () => {
+  test('fires the dedicated Logic Device timeout trigger with formula tokens', async () => {
+    const trigger = { trigger: jest.fn().mockResolvedValue(undefined) };
+    const device = createLogicDeviceHarness();
+    device.homey.flow = { getDeviceTriggerCard: jest.fn(() => trigger) };
+    device.availableInputs = ['a', 'b'];
+    device.parseExpression = jest.fn(() => ['a', 'b']);
+    device.formulas = [{
+      id: 'formula-1',
+      name: 'Main formula',
+      enabled: true,
+      timeout: 1,
+      timedOut: false,
+      lastInputTime: Date.now() - 1001,
+      inputStates: { a: true, b: 'undefined' },
+      expression: 'A AND B',
+    }];
+
+    device.checkTimeouts();
+    await Promise.resolve();
+
+    expect(device.homey.flow.getDeviceTriggerCard).toHaveBeenCalledWith('formula_timeout_ld');
+    expect(trigger.trigger).toHaveBeenCalledWith(device, {
+      formula: { id: 'formula-1', name: 'Main formula' },
+    }, { formulaId: 'formula-1' });
+    expect(device.formulas[0].timedOut).toBe(true);
+  });
+});
+
 describe('LogicDeviceDriver flow cards', () => {
   test('registers formula_result_is_ld condition card', async () => {
     const conditionListeners = {};
+    const triggerListeners = {};
+    const autocompleteListeners = {};
     const createCard = (id) => ({
       id,
       registerRunListener: jest.fn((listener) => {
-        conditionListeners[id] = listener;
+        if (id === 'formula_timeout_ld') triggerListeners[id] = listener;
+        else conditionListeners[id] = listener;
+      }),
+      registerArgumentAutocompleteListener: jest.fn((argName, listener) => {
+        autocompleteListeners[`${id}:${argName}`] = listener;
       }),
     });
     const driver = Object.create(LogicDeviceDriver.prototype);
@@ -178,6 +213,7 @@ describe('LogicDeviceDriver flow cards', () => {
     const device = {
       getName: () => 'Bedtime Group',
       onFlowCondition: jest.fn(async () => true),
+      getFormulas: () => [{ id: 'formula-1', name: 'Main formula' }],
     };
 
     await driver.registerFlowCards();
@@ -192,5 +228,11 @@ describe('LogicDeviceDriver flow cards', () => {
       expect.any(Object),
       true,
     );
+    await expect(triggerListeners.formula_timeout_ld(
+      { formula: { id: 'formula-1' } },
+      { formulaId: 'formula-1' },
+    )).resolves.toBe(true);
+    await expect(autocompleteListeners['formula_timeout_ld:formula']('', { device }))
+      .resolves.toEqual([{ id: 'formula-1', name: 'Main formula' }]);
   });
 });

--- a/no.tiwas.booleantoolbox/drivers/logic-device/device.js
+++ b/no.tiwas.booleantoolbox/drivers/logic-device/device.js
@@ -1626,7 +1626,7 @@ module.exports = class LogicDeviceDevice extends Homey.Device {
           formulaId: formula.id,
         };
         this.homey.flow
-          .getDeviceTriggerCard("formula_timeout")
+          .getDeviceTriggerCard("formula_timeout_ld")
           .trigger(this, triggerData, state)
 
           .catch((err) =>

--- a/no.tiwas.booleantoolbox/drivers/logic-device/driver.js
+++ b/no.tiwas.booleantoolbox/drivers/logic-device/driver.js
@@ -144,6 +144,18 @@ module.exports = class LogicDeviceDriver extends Homey.Driver {
     });
     this.logger.debug(` -> OK: NEW TRIGGER registered: 'device_alarm_turned_ld'`);
 
+    const formulaTimeoutCard = this.homey.flow.getDeviceTriggerCard("formula_timeout_ld");
+    formulaTimeoutCard.registerRunListener(async (args, state) => {
+      const formulaId = args.formula?.id || args.formula;
+      return formulaId === state?.formulaId;
+    });
+    this.registerAutocomplete(formulaTimeoutCard, "formula", async (query, args) => {
+      const formulas = args.device.getFormulas();
+      const normalizedQuery = String(query || '').toLowerCase();
+      return formulas.filter(formula => !normalizedQuery || formula.name.toLowerCase().includes(normalizedQuery));
+    });
+    this.logger.debug(` -> OK: NEW TRIGGER registered: 'formula_timeout_ld'`);
+
 
     // New: Configuration alarm changed to [dropdown selection]
     const configAlarmChangedToCard = this.homey.flow.getTriggerCard("config_alarm_changed_to_ld");


### PR DESCRIPTION
Closes #9\n\nAdds the dedicated Logic Device timeout Flow trigger, registers formula filtering/autocomplete, and fires it with the timed-out formula token and ID state.\n\nValidation:\n- npm test -- --runInBand\n- homey app validate --level=publish\n- node --check drivers/logic-device/device.js drivers/logic-device/driver.js