### PR TITLE
Report partial state application failures

### DIFF
--- a/no.tiwas.booleantoolbox/StateApplication.test.js
+++ b/no.tiwas.booleantoolbox/StateApplication.test.js
@@ -107,6 +107,27 @@ describe('StateDevice application result', () => {
     expect(flow.cards.get('state_applied_successfully_sd').trigger).toHaveBeenCalledTimes(1);
     expect(flow.cards.get('state_error_occurred_sd')).toBeUndefined();
   });
+
+  test('aborts reset-all before activating or applying state when errors are not ignored', async () => {
+    const api = { devices: { getDevice: jest.fn() } };
+    const { device, flow } = createStateDevice(JSON.stringify({
+      config: { ignore_errors: false },
+      items: [{ id: 'light', name: 'Light', capabilities: { onoff: true } }],
+    }), api);
+    const otherState = {
+      getData: () => ({ id: 'other-state' }),
+      getName: () => 'Other state',
+      setCapabilityValue: jest.fn().mockRejectedValue(new Error('reset failed')),
+    };
+    device.driver = { getDevices: () => [otherState, device] };
+
+    await expect(device._executeApply({ reset_all: true })).resolves.toBe(false);
+
+    expect(device.setCapabilityValue).not.toHaveBeenCalled();
+    expect(api.devices.getDevice).not.toHaveBeenCalled();
+    expect(flow.cards.get('state_applied_successfully_sd')).toBeUndefined();
+    expect(flow.cards.get('state_error_occurred_sd').trigger).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('StateCaptureDevice application result', () => {
@@ -180,6 +201,17 @@ describe('StateCaptureDevice application result', () => {
 
     expect(device.stateManager.peekState).toHaveBeenCalledTimes(2);
     expect(device.stateManager.popState).toHaveBeenCalledTimes(2);
+  });
+
+  test('removes a successfully applied stack entry before announcing success', async () => {
+    const { device } = createCaptureDevice({}, { id: 'first' });
+    device._executeApply = jest.fn().mockResolvedValue({ success: true, errors: [] });
+    device._finishFlowApply = jest.fn(() => {
+      expect(device.stateManager.popState).toHaveBeenCalledTimes(1);
+      return true;
+    });
+
+    await expect(device.onFlowPopState({})).resolves.toBe(true);
   });
 
   test('queues stack pushes behind pop-and-apply', async () => {

--- a/no.tiwas.booleantoolbox/StateApplication.test.js
+++ b/no.tiwas.booleantoolbox/StateApplication.test.js
@@ -1,0 +1,136 @@
+'use strict';
+
+jest.mock('homey', () => ({ Device: class {} }), { virtual: true });
+
+const StateDevice = require('./drivers/state-device/device');
+const StateCaptureDevice = require('./drivers/state-capture-device/device');
+
+function createTriggerMap() {
+  const cards = new Map();
+  return {
+    cards,
+    getTriggerCard: jest.fn((id) => {
+      if (!cards.has(id)) cards.set(id, { trigger: jest.fn().mockResolvedValue(undefined) });
+      return cards.get(id);
+    }),
+  };
+}
+
+function createStateDevice(jsonData, api) {
+  const flow = createTriggerMap();
+  const device = Object.create(StateDevice.prototype);
+  device.homey = { app: { api }, flow };
+  device.getSetting = jest.fn((key) => ({ json_data: jsonData, log_errors: true })[key]);
+  device.setCapabilityValue = jest.fn().mockResolvedValue(undefined);
+  device.getData = jest.fn(() => ({ id: 'state-device' }));
+  device.driver = { getDevices: () => [] };
+  device.debug = jest.fn();
+  device.error = jest.fn();
+  device.warn = jest.fn();
+  device.log = jest.fn();
+  return { device, flow };
+}
+
+function createCaptureDevice(api, state) {
+  const flow = createTriggerMap();
+  const device = Object.create(StateCaptureDevice.prototype);
+  device.homey = { app: { api }, flow, __: (key) => key };
+  device.getTemplate = jest.fn(() => ({ items: [] }));
+  device.getSetting = jest.fn(() => true);
+  device.getData = jest.fn(() => ({ id: 'capture-device' }));
+  device.debug = jest.fn();
+  device.error = jest.fn();
+  device.log = jest.fn();
+  device.stateManager = {
+    getState: jest.fn(() => state),
+    peekState: jest.fn(() => state),
+    popState: jest.fn(() => state),
+  };
+  return { device, flow };
+}
+
+describe('StateDevice application result', () => {
+  test.each([
+    ['invalid JSON', '{not valid json'],
+    ['empty configuration', JSON.stringify({ items: [] })],
+  ])('does not emit success for %s', async (_name, jsonData) => {
+    const { device, flow } = createStateDevice(jsonData, { devices: {} });
+
+    await expect(device._executeApply()).resolves.toBe(false);
+
+    expect(flow.cards.get('state_applied_successfully_sd')).toBeUndefined();
+    expect(flow.cards.get('state_error_occurred_sd').trigger).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not emit success when a configured device is unavailable', async () => {
+    const api = { devices: { getDevice: jest.fn().mockRejectedValue(new Error('Could not reach device')) } };
+    const { device, flow } = createStateDevice(JSON.stringify({
+      items: [{ id: 'missing', name: 'Missing', capabilities: { onoff: true } }],
+    }), api);
+
+    await expect(device._executeApply()).resolves.toBe(false);
+
+    expect(flow.cards.get('state_applied_successfully_sd')).toBeUndefined();
+    expect(flow.cards.get('state_error_occurred_sd').trigger).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not emit success for unsupported capabilities or failed writes', async () => {
+    const api = { devices: { getDevice: jest.fn()
+      .mockResolvedValueOnce({ capabilitiesObj: { dim: { setable: false } } })
+      .mockResolvedValueOnce({ capabilitiesObj: { onoff: { setable: true } }, setCapabilityValue: jest.fn().mockRejectedValue(new Error('Timed out')) }) } };
+    const { device, flow } = createStateDevice(JSON.stringify({
+      items: [
+        { id: 'readonly', name: 'Read only', capabilities: { dim: 0.5 } },
+        { id: 'failing', name: 'Failing', capabilities: { onoff: true } },
+      ],
+    }), api);
+
+    await expect(device._executeApply()).resolves.toBe(false);
+
+    expect(flow.cards.get('state_applied_successfully_sd')).toBeUndefined();
+    expect(flow.cards.get('state_error_occurred_sd').trigger).toHaveBeenCalledTimes(1);
+  });
+
+  test('emits success only after every requested write completes', async () => {
+    const setCapabilityValue = jest.fn().mockResolvedValue(undefined);
+    const api = { devices: { getDevice: jest.fn().mockResolvedValue({
+      capabilitiesObj: { onoff: { setable: true } }, setCapabilityValue,
+    }) } };
+    const { device, flow } = createStateDevice(JSON.stringify({
+      config: { ignore_errors: false },
+      items: [{ id: 'light', name: 'Light', capabilities: { onoff: true } }],
+    }), api);
+
+    await expect(device._executeApply()).resolves.toBe(true);
+
+    expect(setCapabilityValue).toHaveBeenCalledWith('onoff', true);
+    expect(flow.cards.get('state_applied_successfully_sd').trigger).toHaveBeenCalledTimes(1);
+    expect(flow.cards.get('state_error_occurred_sd')).toBeUndefined();
+  });
+});
+
+describe('StateCaptureDevice application result', () => {
+  test('returns failure for empty or unavailable state application', async () => {
+    const { device } = createCaptureDevice(null, { values: {} });
+
+    await expect(device._executeApply({ values: {} })).resolves.toEqual(expect.objectContaining({ success: false }));
+  });
+
+  test('does not fire success for partial application and retains a popped state', async () => {
+    const api = { devices: { getDevice: jest.fn().mockResolvedValue({
+      capabilitiesObj: { onoff: { setable: true } },
+      setCapabilityValue: jest.fn().mockRejectedValue(new Error('Timed out')),
+    }) } };
+    const state = { config: { ignore_errors: true }, zones: {
+      Home: { items: [{ id: 'light', name: 'Light', capabilities: { onoff: true } }] },
+    } };
+    const { device, flow } = createCaptureDevice(api, state);
+
+    await expect(device.onFlowApplyState({ state_name: 'Evening' })).resolves.toBe(false);
+    await expect(device.onFlowPopState({})).resolves.toBe(false);
+
+    expect(flow.cards.get('state_applied_scd')).toBeUndefined();
+    expect(flow.cards.get('capture_error_scd').trigger).toHaveBeenCalledTimes(2);
+    expect(device.stateManager.popState).not.toHaveBeenCalled();
+  });
+});

--- a/no.tiwas.booleantoolbox/StateApplication.test.js
+++ b/no.tiwas.booleantoolbox/StateApplication.test.js
@@ -128,6 +128,19 @@ describe('StateDevice application result', () => {
     expect(flow.cards.get('state_applied_successfully_sd')).toBeUndefined();
     expect(flow.cards.get('state_error_occurred_sd').trigger).toHaveBeenCalledTimes(1);
   });
+
+  test('does not emit success for an item without capability values', async () => {
+    const api = { devices: { getDevice: jest.fn().mockResolvedValue({ capabilitiesObj: {} }) } };
+    const { device, flow } = createStateDevice(JSON.stringify({
+      config: { ignore_errors: false },
+      items: [{ id: 'light', name: 'Light', capabilities: [] }],
+    }), api);
+
+    await expect(device._executeApply()).resolves.toBe(false);
+
+    expect(flow.cards.get('state_applied_successfully_sd')).toBeUndefined();
+    expect(flow.cards.get('state_error_occurred_sd').trigger).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('StateCaptureDevice application result', () => {

--- a/no.tiwas.booleantoolbox/StateApplication.test.js
+++ b/no.tiwas.booleantoolbox/StateApplication.test.js
@@ -134,6 +134,22 @@ describe('StateCaptureDevice application result', () => {
     expect(device.stateManager.popState).not.toHaveBeenCalled();
   });
 
+  test('treats items without capability values as failed application', async () => {
+    const api = { devices: { getDevice: jest.fn().mockResolvedValue({
+      capabilitiesObj: {},
+      setCapabilityValue: jest.fn(),
+    }) } };
+    const state = { config: { ignore_errors: true }, zones: {
+      Home: { items: [{ id: 'light', name: 'Light', capabilities: [] }] },
+    } };
+    const { device, flow } = createCaptureDevice(api, state);
+
+    await expect(device.onFlowApplyState({ state_name: 'Empty item' })).resolves.toBe(false);
+
+    expect(flow.cards.get('state_applied_scd')).toBeUndefined();
+    expect(flow.cards.get('capture_error_scd').trigger).toHaveBeenCalledTimes(1);
+  });
+
   test('serializes concurrent pop-and-apply actions so each removes the state it applied', async () => {
     const { device } = createCaptureDevice({}, { id: 'first' });
     const secondState = { id: 'second' };
@@ -150,10 +166,12 @@ describe('StateCaptureDevice application result', () => {
     const first = device.onFlowPopState({});
     const second = device.onFlowPopState({});
     await Promise.resolve();
+    await Promise.resolve();
     expect(device._executeApply).toHaveBeenCalledTimes(1);
 
     resolveFirst({ success: true, errors: [] });
     await first;
+    await Promise.resolve();
     await Promise.resolve();
     expect(device._executeApply).toHaveBeenCalledTimes(2);
 
@@ -162,5 +180,56 @@ describe('StateCaptureDevice application result', () => {
 
     expect(device.stateManager.peekState).toHaveBeenCalledTimes(2);
     expect(device.stateManager.popState).toHaveBeenCalledTimes(2);
+  });
+
+  test('queues stack pushes behind pop-and-apply', async () => {
+    const { device } = createCaptureDevice({}, { id: 'first' });
+    let resolveApply;
+    let resolvePush;
+    device.stateManager.peekState = jest.fn().mockReturnValue({ id: 'first' });
+    device._executeApply = jest.fn(() => new Promise(resolve => { resolveApply = resolve; }));
+    device._finishFlowApply = jest.fn().mockResolvedValue(true);
+    device.stateManager.pushState = jest.fn(() => new Promise(resolve => { resolvePush = resolve; }));
+
+    const pop = device.onFlowPopState({});
+    await Promise.resolve();
+    await Promise.resolve();
+    const push = device.onFlowPushState({});
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(device.stateManager.pushState).not.toHaveBeenCalled();
+
+    resolveApply({ success: true, errors: [] });
+    await pop;
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(device.stateManager.popState).toHaveBeenCalledTimes(1);
+    expect(device.stateManager.pushState).toHaveBeenCalledTimes(1);
+
+    resolvePush({ depth: 1 });
+    await expect(push).resolves.toBe(true);
+  });
+
+  test('queues stack clearing behind pop-and-apply', async () => {
+    const { device } = createCaptureDevice({}, { id: 'first' });
+    let resolveApply;
+    device.stateManager.peekState = jest.fn().mockReturnValue({ id: 'first' });
+    device._executeApply = jest.fn(() => new Promise(resolve => { resolveApply = resolve; }));
+    device._finishFlowApply = jest.fn().mockResolvedValue(true);
+    device.stateManager.clearStack = jest.fn().mockReturnValue(1);
+
+    const pop = device.onFlowPopState({});
+    await Promise.resolve();
+    await Promise.resolve();
+    const clear = device.onFlowClearStack({});
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(device.stateManager.clearStack).not.toHaveBeenCalled();
+
+    resolveApply({ success: true, errors: [] });
+    await pop;
+    await expect(clear).resolves.toBe(true);
+    expect(device.stateManager.popState).toHaveBeenCalledTimes(1);
+    expect(device.stateManager.clearStack).toHaveBeenCalledTimes(1);
   });
 });

--- a/no.tiwas.booleantoolbox/StateApplication.test.js
+++ b/no.tiwas.booleantoolbox/StateApplication.test.js
@@ -133,4 +133,34 @@ describe('StateCaptureDevice application result', () => {
     expect(flow.cards.get('capture_error_scd').trigger).toHaveBeenCalledTimes(2);
     expect(device.stateManager.popState).not.toHaveBeenCalled();
   });
+
+  test('serializes concurrent pop-and-apply actions so each removes the state it applied', async () => {
+    const { device } = createCaptureDevice({}, { id: 'first' });
+    const secondState = { id: 'second' };
+    let resolveFirst;
+    let resolveSecond;
+    device.stateManager.peekState = jest.fn()
+      .mockReturnValueOnce({ id: 'first' })
+      .mockReturnValueOnce(secondState);
+    device._executeApply = jest.fn()
+      .mockImplementationOnce(() => new Promise(resolve => { resolveFirst = resolve; }))
+      .mockImplementationOnce(() => new Promise(resolve => { resolveSecond = resolve; }));
+    device._finishFlowApply = jest.fn().mockResolvedValue(true);
+
+    const first = device.onFlowPopState({});
+    const second = device.onFlowPopState({});
+    await Promise.resolve();
+    expect(device._executeApply).toHaveBeenCalledTimes(1);
+
+    resolveFirst({ success: true, errors: [] });
+    await first;
+    await Promise.resolve();
+    expect(device._executeApply).toHaveBeenCalledTimes(2);
+
+    resolveSecond({ success: true, errors: [] });
+    await second;
+
+    expect(device.stateManager.peekState).toHaveBeenCalledTimes(2);
+    expect(device.stateManager.popState).toHaveBeenCalledTimes(2);
+  });
 });

--- a/no.tiwas.booleantoolbox/drivers/state-capture-device/device.js
+++ b/no.tiwas.booleantoolbox/drivers/state-capture-device/device.js
@@ -146,6 +146,14 @@ class StateCaptureDevice extends Homey.Device {
                 capsToSet = Object.entries(item.capabilities).map(([k, v]) => ({ capability: k, value: v }));
             }
 
+            if (capsToSet.length === 0) {
+                const error = 'No capability values to apply';
+                this.debug(`Skipping item ${item.name}: ${error}`);
+                errors.push({ device: item.name, device_id: item.id, error });
+                if (!ignoreErrors) return { success: false, errors };
+                continue;
+            }
+
             // Filter for valid/setable capabilities
             const validCaps = [];
             for (const capEntry of capsToSet) {
@@ -347,75 +355,90 @@ class StateCaptureDevice extends Homey.Device {
     // ==================== FLOW ACTIONS: STACK ====================
 
     /**
+     * Serialize all stack mutations. A pop must keep the stack unchanged while
+     * it applies the peeked state, otherwise a concurrent push or clear can
+     * change which entry gets removed afterwards.
+     */
+    async _withStackMutationLock(operation) {
+        const previous = this.stackMutationQueue || Promise.resolve();
+        let release;
+        const current = new Promise(resolve => { release = resolve; });
+        this.stackMutationQueue = current;
+
+        try {
+            await previous.catch(() => {});
+            return await operation();
+        } finally {
+            release();
+            if (this.stackMutationQueue === current) this.stackMutationQueue = null;
+        }
+    }
+
+    /**
      * Flow Action: Push current state onto stack
      */
     async onFlowPushState(args) {
-        const template = this.getTemplate();
-        const api = this.homey.app.api;
+        return this._withStackMutationLock(async () => {
+            const template = this.getTemplate();
+            const api = this.homey.app.api;
 
-        try {
-            const result = await this.stateManager.pushState(
-                this.getDeviceId(),
-                template,
-                api
-            );
+            try {
+                const result = await this.stateManager.pushState(
+                    this.getDeviceId(),
+                    template,
+                    api
+                );
 
-            // Trigger success (state_name is empty for stack operations)
-            await this.homey.flow.getTriggerCard('state_captured_scd')
-                .trigger(this, { state_name: '' })
-                .catch(this.error);
+                // Trigger success (state_name is empty for stack operations)
+                await this.homey.flow.getTriggerCard('state_captured_scd')
+                    .trigger(this, { state_name: '' })
+                    .catch(this.error);
 
-            this.debug(`Pushed state onto stack (depth: ${result.depth})`);
-            return true;
+                this.debug(`Pushed state onto stack (depth: ${result.depth})`);
+                return true;
 
-        } catch (e) {
-            this.error('Push failed:', e);
+            } catch (e) {
+                this.error('Push failed:', e);
 
-            await this.homey.flow.getTriggerCard('capture_error_scd')
-                .trigger(this, { error: e.message, state_name: '' })
-                .catch(this.error);
+                await this.homey.flow.getTriggerCard('capture_error_scd')
+                    .trigger(this, { error: e.message, state_name: '' })
+                    .catch(this.error);
 
-            throw e;
-        }
+                throw e;
+            }
+        });
     }
 
     /**
      * Flow Action: Pop state from stack and apply it
      */
     async onFlowPopState(args) {
-        const previousPop = this.popApplyQueue || Promise.resolve();
-        let finishPop;
-        const currentPop = new Promise(resolve => { finishPop = resolve; });
-        this.popApplyQueue = currentPop;
+        return this._withStackMutationLock(async () => {
+            try {
+                // Get state with template for legacy format conversion
+                const template = this.getTemplate();
+                const state = this.stateManager.peekState(this.getDeviceId(), template);
 
-        try {
-            await previousPop;
-        // Get state with template for legacy format conversion
-            const template = this.getTemplate();
-            const state = this.stateManager.peekState(this.getDeviceId(), template);
+                if (!state) {
+                    throw new Error(this.homey.__('errors.stack_empty') || 'Stack is empty');
+                }
 
-            if (!state) {
-                throw new Error(this.homey.__('errors.stack_empty') || 'Stack is empty');
+                // Use _executeApply with full state object
+                const result = await this._executeApply(state);
+
+                const applied = await this._finishFlowApply(result, '');
+                if (applied) this.stateManager.popState(this.getDeviceId(), template);
+                return applied;
+            } catch (e) {
+                this.error('Pop/Apply failed:', e);
+
+                await this.homey.flow.getTriggerCard('capture_error_scd')
+                    .trigger(this, { error: e.message, state_name: '' })
+                    .catch(this.error);
+
+                throw e;
             }
-
-            // Use _executeApply with full state object
-            const result = await this._executeApply(state);
-
-            const applied = await this._finishFlowApply(result, '');
-            if (applied) this.stateManager.popState(this.getDeviceId(), template);
-            return applied;
-        } catch (e) {
-            this.error('Pop/Apply failed:', e);
-
-            await this.homey.flow.getTriggerCard('capture_error_scd')
-                .trigger(this, { error: e.message, state_name: '' })
-                .catch(this.error);
-
-            throw e;
-        } finally {
-            finishPop();
-            if (this.popApplyQueue === currentPop) this.popApplyQueue = null;
-        }
+        });
     }
 
     /**
@@ -451,9 +474,11 @@ class StateCaptureDevice extends Homey.Device {
      * Flow Action: Clear the stack
      */
     async onFlowClearStack(args) {
-        const count = this.stateManager.clearStack(this.getDeviceId());
-        this.debug(`Cleared stack (${count} items removed)`);
-        return true;
+        return this._withStackMutationLock(async () => {
+            const count = this.stateManager.clearStack(this.getDeviceId());
+            this.debug(`Cleared stack (${count} items removed)`);
+            return true;
+        });
     }
 
     // ==================== FLOW ACTIONS: EXPORT/IMPORT ====================

--- a/no.tiwas.booleantoolbox/drivers/state-capture-device/device.js
+++ b/no.tiwas.booleantoolbox/drivers/state-capture-device/device.js
@@ -47,7 +47,12 @@ class StateCaptureDevice extends Homey.Device {
         const api = this.homey.app.api;
         const template = this.getTemplate();
         const errors = [];
-        const logErrors = this.getSetting('log_errors');
+        if (!stateData || typeof stateData !== 'object') {
+            return { success: false, errors: [{ error: 'Invalid state data' }] };
+        }
+        if (!api) {
+            return { success: false, errors: [{ error: 'Homey API not ready' }] };
+        }
 
         // Build execution queue based on format
         const queue = [];
@@ -105,15 +110,18 @@ class StateCaptureDevice extends Homey.Device {
         }
 
         if (queue.length === 0) {
-            this.debug('Queue empty, nothing to apply.');
-            return { success: true, errors: [] };
+            return { success: false, errors: [{ error: 'State contains no active changes' }] };
         }
 
         this.debug(`Starting apply sequence with ${queue.length} items...`);
 
         // Execute queue
         for (const item of queue) {
-            if (!item.id || !item.capabilities) continue;
+            if (!item.id || !item.capabilities) {
+                errors.push({ device: item.name || 'Unknown', device_id: item.id, error: 'Invalid item configuration' });
+                if (!ignoreErrors) return { success: false, errors };
+                continue;
+            }
 
             let apiDevice;
             try {
@@ -147,16 +155,20 @@ class StateCaptureDevice extends Homey.Device {
                         validCaps.push(capEntry);
                     } else {
                         this.debug(`Skipping ${item.name} (${capId}): Capability is read-only`);
+                        errors.push({ device: item.name, capability: capId, error: 'Capability is read-only' });
                     }
                 } else {
                     this.debug(`Skipping ${item.name} (${capId}): Capability not found`);
+                    errors.push({ device: item.name, capability: capId, error: 'Capability not found' });
                 }
             }
 
             if (validCaps.length === 0) {
                 this.debug(`Skipping item ${item.name}: No valid/setable capabilities`);
+                if (!ignoreErrors) return { success: false, errors };
                 continue;
             }
+            if (!ignoreErrors && errors.length > 0) return { success: false, errors };
 
             // Wait delay before processing
             if (item.delay > 0) {
@@ -195,6 +207,10 @@ class StateCaptureDevice extends Homey.Device {
                         errors.push({ device: item.name, capability: capId, error: errMessage });
                         if (!ignoreErrors) break;
                     }
+                    if (!errors.some(error => error.device === item.name && error.capability === capId && error.error === errMessage)) {
+                        errors.push({ device: item.name, capability: capId, error: errMessage });
+                    }
+                    if (!ignoreErrors) return { success: false, errors };
                 }
 
                 // Small delay between capabilities (same as state-device)
@@ -206,6 +222,22 @@ class StateCaptureDevice extends Homey.Device {
 
         this.debug('Apply sequence completed.');
         return { success: errors.length === 0, errors };
+    }
+
+    async _finishFlowApply(result, stateName) {
+        if (result.success) {
+            await this.homey.flow.getTriggerCard('state_applied_scd')
+                .trigger(this, { state_name: stateName })
+                .catch(this.error);
+            return true;
+        }
+
+        const error = result.errors.map(item => item.error || String(item)).join('; ') || 'State was not applied';
+        this.error(`State application failed: ${error}`);
+        await this.homey.flow.getTriggerCard('capture_error_scd')
+            .trigger(this, { error, state_name: stateName })
+            .catch(this.error);
+        return false;
     }
 
     /**
@@ -280,18 +312,7 @@ class StateCaptureDevice extends Homey.Device {
             // Use _executeApply with full state object (supports both formats)
             const result = await this._executeApply(state);
 
-            // Trigger success
-            await this.homey.flow.getTriggerCard('state_applied_scd')
-                .trigger(this, { state_name: stateName })
-                .catch(this.error);
-
-            if (result.errors.length > 0) {
-                this.debug(`Applied state "${stateName}" with ${result.errors.length} errors`);
-            } else {
-                this.debug(`Applied state "${stateName}" successfully`);
-            }
-
-            return true;
+            return this._finishFlowApply(result, stateName);
 
         } catch (e) {
             this.error('Apply failed:', e);
@@ -364,7 +385,7 @@ class StateCaptureDevice extends Homey.Device {
     async onFlowPopState(args) {
         // Get state with template for legacy format conversion
         const template = this.getTemplate();
-        const state = this.stateManager.popState(this.getDeviceId(), template);
+        const state = this.stateManager.peekState(this.getDeviceId(), template);
 
         if (!state) {
             throw new Error(this.homey.__('errors.stack_empty') || 'Stack is empty');
@@ -374,13 +395,9 @@ class StateCaptureDevice extends Homey.Device {
             // Use _executeApply with full state object
             const result = await this._executeApply(state);
 
-            // Trigger success
-            await this.homey.flow.getTriggerCard('state_applied_scd')
-                .trigger(this, { state_name: '' })
-                .catch(this.error);
-
-            this.debug('Popped and applied state from stack');
-            return true;
+            const applied = await this._finishFlowApply(result, '');
+            if (applied) this.stateManager.popState(this.getDeviceId(), template);
+            return applied;
 
         } catch (e) {
             this.error('Pop/Apply failed:', e);
@@ -409,13 +426,7 @@ class StateCaptureDevice extends Homey.Device {
             // Use _executeApply with full state object
             const result = await this._executeApply(state);
 
-            // Trigger success
-            await this.homey.flow.getTriggerCard('state_applied_scd')
-                .trigger(this, { state_name: '' })
-                .catch(this.error);
-
-            this.debug('Peeked and applied state from stack (not removed)');
-            return true;
+            return this._finishFlowApply(result, '');
 
         } catch (e) {
             this.error('Peek/Apply failed:', e);

--- a/no.tiwas.booleantoolbox/drivers/state-capture-device/device.js
+++ b/no.tiwas.booleantoolbox/drivers/state-capture-device/device.js
@@ -426,9 +426,8 @@ class StateCaptureDevice extends Homey.Device {
                 // Use _executeApply with full state object
                 const result = await this._executeApply(state);
 
-                const applied = await this._finishFlowApply(result, '');
-                if (applied) this.stateManager.popState(this.getDeviceId(), template);
-                return applied;
+                if (result.success) this.stateManager.popState(this.getDeviceId(), template);
+                return this._finishFlowApply(result, '');
             } catch (e) {
                 this.error('Pop/Apply failed:', e);
 

--- a/no.tiwas.booleantoolbox/drivers/state-capture-device/device.js
+++ b/no.tiwas.booleantoolbox/drivers/state-capture-device/device.js
@@ -383,22 +383,27 @@ class StateCaptureDevice extends Homey.Device {
      * Flow Action: Pop state from stack and apply it
      */
     async onFlowPopState(args) {
-        // Get state with template for legacy format conversion
-        const template = this.getTemplate();
-        const state = this.stateManager.peekState(this.getDeviceId(), template);
-
-        if (!state) {
-            throw new Error(this.homey.__('errors.stack_empty') || 'Stack is empty');
-        }
+        const previousPop = this.popApplyQueue || Promise.resolve();
+        let finishPop;
+        const currentPop = new Promise(resolve => { finishPop = resolve; });
+        this.popApplyQueue = currentPop;
 
         try {
+            await previousPop;
+        // Get state with template for legacy format conversion
+            const template = this.getTemplate();
+            const state = this.stateManager.peekState(this.getDeviceId(), template);
+
+            if (!state) {
+                throw new Error(this.homey.__('errors.stack_empty') || 'Stack is empty');
+            }
+
             // Use _executeApply with full state object
             const result = await this._executeApply(state);
 
             const applied = await this._finishFlowApply(result, '');
             if (applied) this.stateManager.popState(this.getDeviceId(), template);
             return applied;
-
         } catch (e) {
             this.error('Pop/Apply failed:', e);
 
@@ -407,6 +412,9 @@ class StateCaptureDevice extends Homey.Device {
                 .catch(this.error);
 
             throw e;
+        } finally {
+            finishPop();
+            if (this.popApplyQueue === currentPop) this.popApplyQueue = null;
         }
     }
 

--- a/no.tiwas.booleantoolbox/drivers/state-device/device.js
+++ b/no.tiwas.booleantoolbox/drivers/state-device/device.js
@@ -205,6 +205,14 @@ class StateDevice extends Homey.Device {
             capsToSet = Object.entries(item.capabilities).map(([k, v]) => ({ capability: k, value: v }));
         }
 
+        if (capsToSet.length === 0) {
+            const error = `${item.name || item.id}: no capability values to apply`;
+            this.debug(`Skipping item ${item.name}: ${error}`);
+            errors.push(error);
+            if (!ignoreErrors) return this._finishApply(errors, logErrors);
+            continue;
+        }
+
         // Filter for valid capabilities BEFORE waiting
         const validCaps = [];
         const errorsBeforeCapabilities = errors.length;

--- a/no.tiwas.booleantoolbox/drivers/state-device/device.js
+++ b/no.tiwas.booleantoolbox/drivers/state-device/device.js
@@ -64,8 +64,25 @@ class StateDevice extends Homey.Device {
 
   async _executeApply(options = {}) {
     this.debug('Applying state configuration...', options);
+    const jsonStr = this.getSetting('json_data');
+    const logErrors = this.getSetting('log_errors');
+
+    if (!jsonStr) {
+      this.error('No configuration data found.');
+      return this._finishApply(['No configuration data found'], logErrors);
+    }
+
+    let configObj;
+    try {
+        configObj = JSON.parse(jsonStr);
+    } catch (e) {
+        this.error('Invalid JSON configuration:', e);
+        return this._finishApply(['Invalid JSON configuration'], logErrors);
+    }
+
+    const ignoreErrors = configObj.config?.ignore_errors !== false;
     const preApplyErrors = [];
-    
+
     // 1. Handle Reset All
     if (options.reset_all) {
         this.debug('Resetting all other state devices...');
@@ -77,43 +94,35 @@ class StateDevice extends Homey.Device {
                 // Turn off without triggering logic? Or just set value.
                 // Using setCapabilityValue triggers listeners usually.
                 // We just want to visually turn them off.
-                await device.setCapabilityValue('onoff', false).catch((error) => {
-                    preApplyErrors.push(`Failed to reset ${device.getName?.() || device.getData().id}: ${error.message || error}`);
-                });
+                try {
+                  await device.setCapabilityValue('onoff', false);
+                } catch (error) {
+                  const message = `Failed to reset ${device.getName?.() || device.getData().id}: ${error.message || error}`;
+                  preApplyErrors.push(message);
+                  if (!ignoreErrors) return this._finishApply(preApplyErrors, logErrors);
+                }
             }
         } catch (e) {
             this.error('Error resetting other devices:', e);
             preApplyErrors.push(`Failed to reset other state devices: ${e.message || e}`);
+            if (!ignoreErrors) return this._finishApply(preApplyErrors, logErrors);
         }
     }
 
     // 2. Set Self to ON
-    await this.setCapabilityValue('onoff', true).catch((error) => {
+    try {
+      await this.setCapabilityValue('onoff', true);
+    } catch (error) {
       this.error(error);
       preApplyErrors.push(`Failed to activate this state device: ${error.message || error}`);
-    });
-    
-    const jsonStr = this.getSetting('json_data');
-    const logErrors = this.getSetting('log_errors');
+      if (!ignoreErrors) return this._finishApply(preApplyErrors, logErrors);
+    }
+
     const errors = [...preApplyErrors];
-
-    if (!jsonStr) {
-      this.error('No configuration data found.');
-      return this._finishApply([...errors, 'No configuration data found'], logErrors);
-    }
-
-    let configObj;
-    try {
-        configObj = JSON.parse(jsonStr);
-    } catch (e) {
-        this.error('Invalid JSON configuration:', e);
-        return this._finishApply([...errors, 'Invalid JSON configuration'], logErrors);
-    }
 
     // 3. Build Execution Queue (Handle Hierarchical vs Flat)
     const queue = [];
     const globalDelay = configObj.config?.default_delay || 200;
-    const ignoreErrors = configObj.config?.ignore_errors !== false;
 
     // Logic to parse zones/items
     if (configObj.zones) {

--- a/no.tiwas.booleantoolbox/drivers/state-device/device.js
+++ b/no.tiwas.booleantoolbox/drivers/state-device/device.js
@@ -40,12 +40,31 @@ class StateDevice extends Homey.Device {
   }
 
   async onFlowActionApplyState(args) {
-      const resetAll = args.reset_all === true;
-      return this._executeApply({ reset_all: resetAll });
+    const resetAll = args.reset_all === true;
+    return this._executeApply({ reset_all: resetAll });
+  }
+
+  async _finishApply(errors, logErrors) {
+    if (errors.length > 0) {
+      const error = errors.join('; ');
+      this.error(`State application completed with ${errors.length} error(s): ${error}`);
+      if (logErrors) {
+        await this.homey.flow.getTriggerCard('state_error_occurred_sd')
+          .trigger(this, { error })
+          .catch(this.error);
+      }
+      return false;
+    }
+
+    await this.homey.flow.getTriggerCard('state_applied_successfully_sd')
+      .trigger(this)
+      .catch(this.error);
+    return true;
   }
 
   async _executeApply(options = {}) {
     this.debug('Applying state configuration...', options);
+    const preApplyErrors = [];
     
     // 1. Handle Reset All
     if (options.reset_all) {
@@ -58,22 +77,29 @@ class StateDevice extends Homey.Device {
                 // Turn off without triggering logic? Or just set value.
                 // Using setCapabilityValue triggers listeners usually.
                 // We just want to visually turn them off.
-                await device.setCapabilityValue('onoff', false).catch(() => {});
+                await device.setCapabilityValue('onoff', false).catch((error) => {
+                    preApplyErrors.push(`Failed to reset ${device.getName?.() || device.getData().id}: ${error.message || error}`);
+                });
             }
         } catch (e) {
             this.error('Error resetting other devices:', e);
+            preApplyErrors.push(`Failed to reset other state devices: ${e.message || e}`);
         }
     }
 
     // 2. Set Self to ON
-    await this.setCapabilityValue('onoff', true).catch(this.error);
+    await this.setCapabilityValue('onoff', true).catch((error) => {
+      this.error(error);
+      preApplyErrors.push(`Failed to activate this state device: ${error.message || error}`);
+    });
     
     const jsonStr = this.getSetting('json_data');
     const logErrors = this.getSetting('log_errors');
+    const errors = [...preApplyErrors];
 
     if (!jsonStr) {
-        this.error('No configuration data found.');
-        return;
+      this.error('No configuration data found.');
+      return this._finishApply([...errors, 'No configuration data found'], logErrors);
     }
 
     let configObj;
@@ -81,8 +107,7 @@ class StateDevice extends Homey.Device {
         configObj = JSON.parse(jsonStr);
     } catch (e) {
         this.error('Invalid JSON configuration:', e);
-        if (logErrors) this.homey.flow.getTriggerCard('state_error_occurred_sd').trigger(this, { error: 'Invalid JSON' }).catch(this.error);
-        return;
+        return this._finishApply([...errors, 'Invalid JSON configuration'], logErrors);
     }
 
     // 3. Build Execution Queue (Handle Hierarchical vs Flat)
@@ -125,22 +150,24 @@ class StateDevice extends Homey.Device {
     }
 
     if (queue.length === 0) {
-        this.debug('Queue empty, nothing to do.');
-        return;
+        return this._finishApply([...errors, 'Configuration contains no active state changes'], logErrors);
     }
 
     // 4. Execute Queue
     const api = this.homey.app.api;
     if (!api) {
-        this.error('Homey API not ready.');
-        return;
+        return this._finishApply([...errors, 'Homey API not ready'], logErrors);
     }
 
     this.debug(`Starting sequence with ${queue.length} items...`);
 
     for (const item of queue) {
         // Execute Item
-        if (!item.id || !item.capabilities) continue;
+        if (!item.id || !item.capabilities) {
+            errors.push(`Invalid item configuration for ${item.name || 'unnamed device'}`);
+            if (!ignoreErrors) return this._finishApply(errors, logErrors);
+            continue;
+        }
 
         let apiDevice;
         try {
@@ -153,9 +180,10 @@ class StateDevice extends Homey.Device {
                  this.error(`Failed to get device ${item.name}:`, e);
              }
              if (!ignoreErrors) {
-                 this.homey.flow.getTriggerCard('state_error_occurred_sd').trigger(this, { error: errMessage }).catch(this.error);
-                 return;
+                 errors.push(errMessage);
+                 return this._finishApply(errors, logErrors);
              }
+             errors.push(errMessage);
              continue; // Skip processing this item
         }
 
@@ -170,6 +198,7 @@ class StateDevice extends Homey.Device {
 
         // Filter for valid capabilities BEFORE waiting
         const validCaps = [];
+        const errorsBeforeCapabilities = errors.length;
         for (const capEntry of capsToSet) {
             const capId = capEntry.capability || capEntry.id;
             
@@ -180,15 +209,21 @@ class StateDevice extends Homey.Device {
                     validCaps.push(capEntry);
                 } else {
                     this.warn(`Skipping ${item.name} (${capId}): Capability is read-only.`);
+                    errors.push(`${item.name || item.id}: ${capId} is read-only`);
                 }
             } else {
                 this.warn(`Skipping ${item.name} (${capId}): Capability not found on device.`);
+                errors.push(`${item.name || item.id}: ${capId} is not available`);
             }
         }
 
         if (validCaps.length === 0) {
             this.debug(`Skipping item ${item.name}: No valid/setable capabilities found.`);
+            if (!ignoreErrors) return this._finishApply(errors, logErrors);
             continue; // Skip delay!
+        }
+        if (!ignoreErrors && errors.length > errorsBeforeCapabilities) {
+            return this._finishApply(errors, logErrors);
         }
 
         // Wait Delay (Only if we actually have work to do)
@@ -213,17 +248,15 @@ class StateDevice extends Homey.Device {
                     this.log(`[WARN] Skipped ${item.name} (${capId}): Device driver does not support controlling this capability.`);
                 } else if (typeof errMessage === 'string' && errMessage.includes('TRANSMIT_COMPLETE_NO_ACK')) {
                     this.error(`[NETWORK] Failed to set ${item.name} (${capId}): Device did not respond.`);
-                    if (!ignoreErrors) throw capError;
                 } else if (typeof errMessage === 'string' && (errMessage.includes('device is currently unavailable') || errMessage.includes('Could not reach device'))) {
                     this.error(`[UNREACHABLE] Failed to set ${item.name} (${capId}): Device is unavailable or unreachable.`);
-                    if (!ignoreErrors) throw capError;
                 } else if (capError.code === 'TIMEOUT' || (typeof errMessage === 'string' && errMessage.includes('Timed out'))) {
                     this.error(`[TIMEOUT] Failed to set ${item.name} (${capId}): Operation timed out.`);
-                    if (!ignoreErrors) throw capError;
                 } else {
                     this.error(`Failed to set ${item.name} (${capId}):`, capError);
-                    if (!ignoreErrors) throw capError;
                 }
+                errors.push(`${item.name || item.id}: failed to set ${capId}: ${errMessage}`);
+                if (!ignoreErrors) return this._finishApply(errors, logErrors);
             }
 
             // Add a small delay between capabilities
@@ -233,8 +266,7 @@ class StateDevice extends Homey.Device {
         }
     }
 
-    this.debug('Sequence completed.');
-    this.homey.flow.getTriggerCard('state_applied_successfully_sd').trigger(this).catch(this.error);
+    return this._finishApply(errors, logErrors);
   }
 
 }


### PR DESCRIPTION
Closes #10\n\nState applications now return true and emit success only after every requested write completes. Invalid/empty configuration, unavailable APIs/devices, unsupported capabilities, write errors, and reset failures return false and report through the error trigger. Failed pop application keeps the stack entry.\n\nValidation:\n- npm test -- --runInBand\n- homey app validate --level=publish\n- node --check modified runtime files