### PR TITLE
Fix captured-state import/export round trips

### DIFF
--- a/no.tiwas.booleantoolbox/CapturedStateManager.test.js
+++ b/no.tiwas.booleantoolbox/CapturedStateManager.test.js
@@ -1,0 +1,58 @@
+const CapturedStateManager = require('./lib/CapturedStateManager');
+
+function createManager() {
+  CapturedStateManager.instance = null;
+  const store = new Map();
+  const homey = {
+    settings: {
+      get: jest.fn(key => store.get(key)),
+      set: jest.fn((key, value) => store.set(key, value)),
+      unset: jest.fn(key => store.delete(key)),
+    },
+  };
+  const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+  return new CapturedStateManager(homey, logger);
+}
+
+afterEach(() => {
+  CapturedStateManager.instance = null;
+});
+
+describe('CapturedStateManager named state import/export', () => {
+  test.each([
+    ['hierarchical', {
+      captured_at: '2026-09-05T00:00:00.000Z',
+      config: { default_delay: 250, ignore_errors: false },
+      metadata: { source: 'backup', label: 'Evening' },
+      zones: {
+        LivingRoom: {
+          config: { delay_between: 100 },
+          items: [{
+            id: 'light-1',
+            name: 'Lamp',
+            active: true,
+            capabilities: [{ capability: 'onoff', value: true }, { capability: 'dim', value: 0.5 }],
+          }],
+        },
+      },
+    }],
+    ['legacy flat', {
+      captured_at: '2026-09-05T00:00:00.000Z',
+      config: { default_delay: 250 },
+      metadata: { source: 'legacy-backup' },
+      values: { 'light-1': { onoff: true, dim: 0.5 } },
+    }],
+  ])('round-trips %s named states through export and import', (_format, state) => {
+    const manager = createManager();
+    const deviceId = 'capture-device';
+
+    manager.setStateFromJson(deviceId, 'Evening', state);
+    const exported = manager.exportNamedStates(deviceId);
+
+    manager.cleanupDevice(deviceId);
+    const result = manager.importNamedStates(deviceId, exported);
+
+    expect(result).toEqual({ imported: 1, overwritten: 0, errors: [] });
+    expect(manager.exportNamedStates(deviceId)).toEqual(exported);
+  });
+});

--- a/no.tiwas.booleantoolbox/CapturedStateManager.test.js
+++ b/no.tiwas.booleantoolbox/CapturedStateManager.test.js
@@ -55,4 +55,19 @@ describe('CapturedStateManager named state import/export', () => {
     expect(result).toEqual({ imported: 1, overwritten: 0, errors: [] });
     expect(manager.exportNamedStates(deviceId)).toEqual(exported);
   });
+
+  test('rejects malformed hierarchical zone records during import', () => {
+    const manager = createManager();
+
+    const result = manager.importNamedStates('capture-device', {
+      states: { Broken: { zones: { Kitchen: [] } } },
+    });
+
+    expect(result.imported).toBe(0);
+    expect(result.errors).toEqual([{
+      name: 'Broken',
+      error: 'Invalid zone "Kitchen": expected object',
+    }]);
+    expect(manager.listStateNames('capture-device')).toEqual([]);
+  });
 });

--- a/no.tiwas.booleantoolbox/lib/CapturedStateManager.js
+++ b/no.tiwas.booleantoolbox/lib/CapturedStateManager.js
@@ -378,7 +378,7 @@ class CapturedStateManager {
      */
     _validateHierarchicalState(stateData) {
         for (const [zoneName, zoneData] of Object.entries(stateData.zones)) {
-            if (!zoneData || typeof zoneData !== 'object') {
+            if (!zoneData || typeof zoneData !== 'object' || Array.isArray(zoneData)) {
                 throw new Error(`Invalid zone "${zoneName}": expected object`);
             }
 

--- a/no.tiwas.booleantoolbox/lib/CapturedStateManager.js
+++ b/no.tiwas.booleantoolbox/lib/CapturedStateManager.js
@@ -546,7 +546,7 @@ class CapturedStateManager {
     /**
      * Export all named states as JSON object
      * @param {string} deviceId - State capture device ID
-     * @returns {object} - { states: { name: { captured_at, values }, ... } }
+     * @returns {object} - { states: { name: stateData, ... } }
      */
     exportNamedStates(deviceId) {
         const data = this._getDeviceData(deviceId);
@@ -585,9 +585,17 @@ class CapturedStateManager {
                     continue;
                 }
 
-                if (!stateData.values || typeof stateData.values !== 'object') {
-                    errors.push({ name: stateName, error: 'Missing or invalid values' });
+                const isHierarchical = stateData.zones && typeof stateData.zones === 'object' && !Array.isArray(stateData.zones);
+                const isFlat = stateData.values && typeof stateData.values === 'object' && !Array.isArray(stateData.values);
+                if (!isHierarchical && !isFlat) {
+                    errors.push({ name: stateName, error: 'Missing or invalid zones or values' });
                     continue;
+                }
+
+                if (isHierarchical) {
+                    this._validateHierarchicalState(stateData);
+                } else {
+                    this._validateFlatState(stateData);
                 }
 
                 // Check if we're overwriting
@@ -595,10 +603,11 @@ class CapturedStateManager {
                     overwritten++;
                 }
 
-                // Import the state
+                // Preserve all supported state configuration and metadata so an
+                // export can be imported without changing the stored format.
                 data.named[stateName] = {
-                    captured_at: stateData.captured_at || new Date().toISOString(),
-                    values: stateData.values
+                    ...stateData,
+                    captured_at: stateData.captured_at || new Date().toISOString()
                 };
                 imported++;
 


### PR DESCRIPTION
Fixes #11\n\nSupports current hierarchical exports as well as legacy flat exports, preserving state configuration and metadata.