### PR TITLE
Fix: sanitize imported floorplan SVG

### DIFF
--- a/apps/dashboard/shared/package-lock.json
+++ b/apps/dashboard/shared/package-lock.json
@@ -8,9 +8,138 @@
       "name": "@homey-toolbox/dashboard-shared",
       "version": "0.0.1",
       "devDependencies": {
-        "happy-dom": "^20.14.0",
+        "jsdom": "^26.1.0",
         "tsx": "^4.21.0",
         "typescript": "^5.4.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -455,58 +584,68 @@
         "node": ">=18"
       }
     },
-    "node_modules/@types/node": {
-      "version": "26.4.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
-      "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~8.3.0"
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
-    "node_modules/@types/whatwg-mimetype": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
-      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/buffer-image-size": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
-      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      },
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/entities": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
-      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
     },
     "node_modules/esbuild": {
       "version": "0.28.2",
@@ -565,23 +704,242 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/happy-dom": {
-      "version": "20.14.0",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.14.0.tgz",
-      "integrity": "sha512-4bRh1KzRvKDnFNTlLhzT1RZTpkKhQbQDl9j+7GXszWsvuspYdo29k6OHRf4PwiM6oLb8r/pMWeYiJjkfod5AvQ==",
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/node": ">=20.0.0",
-        "@types/whatwg-mimetype": "^3.0.2",
-        "@types/ws": "^8.18.1",
-        "buffer-image-size": "^0.6.4",
-        "entities": "^7.0.1",
-        "whatwg-mimetype": "^3.0.0",
-        "ws": "^8.21.0"
+        "whatwg-encoding": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.27",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.27.tgz",
+      "integrity": "sha512-gQPNF78qebCQ6tvVFBYrvJdBNOrYZm90ZlXgpIFm06p6qHDHq/XC4TnJftN6OMbxVE0UTBAoRgcsDeJBBooITw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tsx": {
@@ -617,21 +975,65 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/whatwg-mimetype": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
-      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ws": {
@@ -655,6 +1057,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/apps/dashboard/shared/package-lock.json
+++ b/apps/dashboard/shared/package-lock.json
@@ -8,7 +8,599 @@
       "name": "@homey-toolbox/dashboard-shared",
       "version": "0.0.1",
       "devDependencies": {
+        "happy-dom": "^20.14.0",
+        "tsx": "^4.21.0",
         "typescript": "^5.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
+      "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.14.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.14.0.tgz",
+      "integrity": "sha512-4bRh1KzRvKDnFNTlLhzT1RZTpkKhQbQDl9j+7GXszWsvuspYdo29k6OHRf4PwiM6oLb8r/pMWeYiJjkfod5AvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.13",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.13.tgz",
+      "integrity": "sha512-BL5MGkRln6aDYhb0xbQlEAGw743BaZYWdbWtdJOBriYJboKgUUYCadFp2/FpBBZquBC/ezNBn7wMMPx7FDZUDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/typescript": {
@@ -23,6 +615,45 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     }
   }

--- a/apps/dashboard/shared/package.json
+++ b/apps/dashboard/shared/package.json
@@ -11,7 +11,7 @@
     "test:floorplan": "tsx test/floorplan-sanitizer.ts"
   },
   "devDependencies": {
-    "happy-dom": "^20.14.0",
+    "jsdom": "^26.1.0",
     "tsx": "^4.21.0",
     "typescript": "^5.4.0"
   }

--- a/apps/dashboard/shared/package.json
+++ b/apps/dashboard/shared/package.json
@@ -7,9 +7,12 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:floorplan": "tsx test/floorplan-sanitizer.ts"
   },
   "devDependencies": {
+    "happy-dom": "^20.14.0",
+    "tsx": "^4.21.0",
     "typescript": "^5.4.0"
   }
 }

--- a/apps/dashboard/shared/src/floorplan.ts
+++ b/apps/dashboard/shared/src/floorplan.ts
@@ -36,7 +36,7 @@ const MAX_SVG_SIZE = 1_000_000;
 const MAX_SVG_ELEMENTS = 10_000;
 const MAX_SVG_ATTRIBUTES = 50_000;
 const SAFE_SVG_ELEMENTS = new Set([
-  "svg", "g", "defs", "desc", "title", "view", "path", "rect", "circle", "ellipse", "line",
+  "svg", "g", "defs", "view", "switch", "path", "rect", "circle", "ellipse", "line",
   "polyline", "polygon", "text", "tspan", "textpath", "use", "symbol", "marker", "pattern",
   "clippath", "mask", "lineargradient", "radialgradient", "stop", "filter", "feblend",
   "fecolormatrix", "fecomponenttransfer", "fecomposite", "feconvolvematrix", "fediffuselighting",
@@ -47,6 +47,15 @@ const SAFE_SVG_ELEMENTS = new Set([
 
 function hasOnlyLocalUrlReferences(value: string): boolean {
   const normalized = value.toLowerCase();
+  if (
+    normalized.includes("image(") ||
+    normalized.includes("image-set(") ||
+    normalized.includes("cross-fade(") ||
+    normalized.includes("element(") ||
+    normalized.includes("paint(")
+  ) {
+    return false;
+  }
   let cursor = 0;
   while (true) {
     const start = normalized.indexOf("url(", cursor);
@@ -168,10 +177,11 @@ export function validateSvg(input: string): { ok: true; svg: string } | { ok: fa
 
       const name = attribute.name.toLowerCase();
       const value = attribute.value.trim();
-      const isUrlAttribute = name === "href" || name === "xlink:href" || name === "src" || name === "srcset";
+      const isUrlAttribute = name === "href" || name === "xlink:href" || name === "src";
       if (
         name.startsWith("on") ||
         name === "style" ||
+        name === "srcset" ||
         value.includes("\\") ||
         (isUrlAttribute && !isSafeSvgReference(value)) ||
         !hasOnlyLocalUrlReferences(value)
@@ -308,26 +318,30 @@ function removeFloorsExcept(svg: string, keep: Set<string>): string {
     const name = open[1] ?? "";
     const startIdx = open.index;
     const headerEnd = startIdx + open[0].length;
+    const isSelfClosing = /\/\s*>$/.test(open[0]);
     if (keep.has(name)) {
       // Replace the attribute so we don't re-match, but keep the group.
       const replaced = open[0].replace(/data-floor="[^"]*"/i, `data-floor-kept="${name}"`);
       out = out.slice(0, startIdx) + replaced + out.slice(headerEnd);
       continue;
     }
+    if (isSelfClosing) {
+      out = out.slice(0, startIdx) + out.slice(headerEnd);
+      continue;
+    }
     // Find the matching </g> by counting nesting depth.
     let depth = 1;
     let i = headerEnd;
-    while (i < out.length && depth > 0) {
-      const nextOpen = out.toLowerCase().indexOf("<g", i);
-      const nextClose = out.toLowerCase().indexOf("</g>", i);
-      if (nextClose === -1) break;
-      if (nextOpen !== -1 && nextOpen < nextClose) {
-        depth++;
-        i = nextOpen + 2;
-      } else {
+    const tagRegex = /<g\b[^>]*\/?>|<\/g\s*>/gi;
+    tagRegex.lastIndex = headerEnd;
+    let tag: RegExpExecArray | null;
+    while ((tag = tagRegex.exec(out)) !== null && depth > 0) {
+      if (tag[0].startsWith("</")) {
         depth--;
-        i = nextClose + 4;
+      } else if (!/\/\s*>$/.test(tag[0])) {
+        depth++;
       }
+      i = tagRegex.lastIndex;
     }
     out = out.slice(0, startIdx) + out.slice(i);
   }

--- a/apps/dashboard/shared/src/floorplan.ts
+++ b/apps/dashboard/shared/src/floorplan.ts
@@ -14,7 +14,7 @@ export interface DevicePlacement {
 }
 
 export interface FloorplanData {
-  /** Raw SVG document as a string. Validated to contain a single <svg> root. */
+  /** Sanitized SVG document, safe to render in the dashboard WebView. */
   svg: string;
   /** Device/flow placements anchored to SVG coordinates. */
   placements: DevicePlacement[];
@@ -32,10 +32,32 @@ export const EMPTY_FLOORPLAN: FloorplanData = {
   hiddenFlows: [],
 };
 
+const MAX_SVG_SIZE = 1_000_000;
+const MAX_SVG_ELEMENTS = 10_000;
+const MAX_SVG_ATTRIBUTES = 50_000;
+const UNSAFE_SVG_ELEMENTS = new Set([
+  "script", "foreignobject", "iframe", "object", "embed", "style", "link",
+  "base", "meta", "animate", "animatemotion", "animatetransform", "set",
+]);
+
+function hasOnlyLocalUrlReferences(value: string): boolean {
+  const matches = value.matchAll(/url\(\s*(['"]?)(.*?)\1\s*\)/gi);
+  for (const match of matches) {
+    if (!(match[2] ?? "").trim().startsWith("#")) return false;
+  }
+  return true;
+}
+
+function isSafeSvgReference(value: string): boolean {
+  return value.trim().startsWith("#");
+}
+
 export function normalizeFloorplan(raw: unknown): FloorplanData {
   if (raw == null || typeof raw !== "object") return EMPTY_FLOORPLAN;
   const obj = raw as Record<string, unknown>;
-  const svg = typeof obj.svg === "string" ? obj.svg : "";
+  const svgInput = typeof obj.svg === "string" ? obj.svg : "";
+  const svgResult = svgInput ? validateSvg(svgInput) : null;
+  const svg = svgResult?.ok ? svgResult.svg : "";
   const placements = Array.isArray(obj.placements)
     ? (obj.placements
         .map(normalizePlacement)
@@ -76,21 +98,57 @@ function normalizePlacement(raw: unknown): DevicePlacement | null {
   };
 }
 
-/**
- * Cheap validation: does the input look like a single-root SVG document?
- * Doesn't try to parse XML fully — we accept anything that has an opening
- * `<svg` tag and at least one closing `</svg>`. The webview will reject
- * malformed XML at render time anyway.
- */
 export function validateSvg(input: string): { ok: true; svg: string } | { ok: false; error: string } {
   const trimmed = input.trim();
   if (!trimmed) return { ok: false, error: "empty input" };
-  const openIdx = trimmed.toLowerCase().indexOf("<svg");
-  const closeIdx = trimmed.toLowerCase().lastIndexOf("</svg>");
-  if (openIdx === -1 || closeIdx === -1 || closeIdx < openIdx) {
-    return { ok: false, error: "no <svg>…</svg> root found" };
+  if (trimmed.length > MAX_SVG_SIZE) {
+    return { ok: false, error: "SVG exceeds the 1 MB size limit" };
   }
-  return { ok: true, svg: trimmed.slice(openIdx, closeIdx + "</svg>".length) };
+  if (typeof DOMParser === "undefined" || typeof XMLSerializer === "undefined") {
+    return { ok: false, error: "SVG validation is unavailable in this environment" };
+  }
+
+  const svgDocument = new DOMParser().parseFromString(trimmed, "image/svg+xml");
+  if (svgDocument.querySelector("parsererror")) {
+    return { ok: false, error: "SVG is not valid XML" };
+  }
+  if (svgDocument.documentElement?.localName.toLowerCase() !== "svg") {
+    return { ok: false, error: "document root must be <svg>" };
+  }
+
+  const elements = Array.from(svgDocument.querySelectorAll("*"));
+  if (elements.length > MAX_SVG_ELEMENTS) {
+    return { ok: false, error: "SVG exceeds the element limit" };
+  }
+
+  let attributeCount = 0;
+  for (const element of elements) {
+    if (UNSAFE_SVG_ELEMENTS.has(element.localName.toLowerCase())) {
+      element.remove();
+      continue;
+    }
+
+    for (const attribute of Array.from(element.attributes)) {
+      attributeCount += 1;
+      if (attributeCount > MAX_SVG_ATTRIBUTES) {
+        return { ok: false, error: "SVG exceeds the attribute limit" };
+      }
+
+      const name = attribute.name.toLowerCase();
+      const value = attribute.value.trim();
+      const isUrlAttribute = name === "href" || name === "xlink:href" || name === "src";
+      if (
+        name.startsWith("on") ||
+        name === "style" ||
+        (isUrlAttribute && !isSafeSvgReference(value)) ||
+        !hasOnlyLocalUrlReferences(value)
+      ) {
+        element.removeAttribute(attribute.name);
+      }
+    }
+  }
+
+  return { ok: true, svg: new XMLSerializer().serializeToString(svgDocument.documentElement) };
 }
 
 /**

--- a/apps/dashboard/shared/src/floorplan.ts
+++ b/apps/dashboard/shared/src/floorplan.ts
@@ -35,9 +35,14 @@ export const EMPTY_FLOORPLAN: FloorplanData = {
 const MAX_SVG_SIZE = 1_000_000;
 const MAX_SVG_ELEMENTS = 10_000;
 const MAX_SVG_ATTRIBUTES = 50_000;
-const UNSAFE_SVG_ELEMENTS = new Set([
-  "script", "foreignobject", "iframe", "object", "embed", "style", "link",
-  "base", "meta", "animate", "animatemotion", "animatetransform", "set",
+const SAFE_SVG_ELEMENTS = new Set([
+  "svg", "g", "defs", "desc", "title", "view", "path", "rect", "circle", "ellipse", "line",
+  "polyline", "polygon", "text", "tspan", "textpath", "use", "symbol", "marker", "pattern",
+  "clippath", "mask", "lineargradient", "radialgradient", "stop", "filter", "feblend",
+  "fecolormatrix", "fecomponenttransfer", "fecomposite", "feconvolvematrix", "fediffuselighting",
+  "fedisplacementmap", "fedistantlight", "fedropshadow", "feflood", "fefunca", "fefuncb", "fefuncg",
+  "fefuncr", "fegaussianblur", "feimage", "femerge", "femergenode", "femorphology", "feoffset",
+  "fepointlight", "fespecularlighting", "fespotlight", "fetile", "feturbulence", "image", "a",
 ]);
 
 function hasOnlyLocalUrlReferences(value: string): boolean {
@@ -63,12 +68,12 @@ function isSafeSvgReference(value: string): boolean {
   return value.trim().startsWith("#");
 }
 
-function removeComments(node: Node): void {
+function removeOpaqueNodes(node: Node): void {
   for (const child of Array.from(node.childNodes)) {
-    if (child.nodeType === 7 || child.nodeType === 8) {
+    if (child.nodeType !== 1 && child.nodeType !== 3) {
       child.remove();
     } else {
-      removeComments(child);
+      removeOpaqueNodes(child);
     }
   }
 }
@@ -150,7 +155,7 @@ export function validateSvg(input: string): { ok: true; svg: string } | { ok: fa
 
   let attributeCount = 0;
   for (const element of elements) {
-    if (element.prefix || UNSAFE_SVG_ELEMENTS.has(element.localName.toLowerCase())) {
+    if (element.prefix || !SAFE_SVG_ELEMENTS.has(element.localName.toLowerCase())) {
       element.remove();
       continue;
     }
@@ -176,7 +181,7 @@ export function validateSvg(input: string): { ok: true; svg: string } | { ok: fa
     }
   }
 
-  removeComments(svgDocument);
+  removeOpaqueNodes(svgDocument);
   const svg = new XMLSerializer().serializeToString(svgDocument.documentElement);
   if (svg.length > MAX_SVG_SIZE) {
     return { ok: false, error: "SVG exceeds the 1 MB size limit after parsing" };

--- a/apps/dashboard/shared/src/floorplan.ts
+++ b/apps/dashboard/shared/src/floorplan.ts
@@ -35,6 +35,7 @@ export const EMPTY_FLOORPLAN: FloorplanData = {
 const MAX_SVG_SIZE = 1_000_000;
 const MAX_SVG_ELEMENTS = 10_000;
 const MAX_SVG_ATTRIBUTES = 50_000;
+const MAX_SVG_DEPTH = 256;
 const SAFE_SVG_ELEMENTS = new Set([
   "svg", "g", "defs", "view", "switch", "path", "rect", "circle", "ellipse", "line",
   "polyline", "polygon", "text", "tspan", "textpath", "use", "symbol", "marker", "pattern",
@@ -44,21 +45,39 @@ const SAFE_SVG_ELEMENTS = new Set([
   "fefuncr", "fegaussianblur", "feimage", "femerge", "femergenode", "femorphology", "feoffset",
   "fepointlight", "fespecularlighting", "fespotlight", "fetile", "feturbulence", "image", "a",
 ]);
+const CSS_URL_ATTRIBUTES = new Set([
+  "fill", "stroke", "filter", "clip-path", "mask", "marker-start", "marker-mid", "marker-end", "cursor",
+]);
+const FORBIDDEN_SVG_ATTRIBUTES = new Set([
+  "base", "xml:base", "style", "srcset", "mask-image", "background", "background-image", "border-image",
+  "content", "list-style-image", "poster", "shape-outside",
+]);
+
+function indexOfAsciiIgnoreCase(value: string, needle: string, from = 0): number {
+  outer: for (let index = from; index <= value.length - needle.length; index += 1) {
+    for (let offset = 0; offset < needle.length; offset += 1) {
+      const actual = value.charCodeAt(index + offset);
+      const expected = needle.charCodeAt(offset);
+      if (actual !== expected && actual !== expected - 32) continue outer;
+    }
+    return index;
+  }
+  return -1;
+}
 
 function hasOnlyLocalUrlReferences(value: string): boolean {
-  const normalized = value.toLowerCase();
   if (
-    normalized.includes("image(") ||
-    normalized.includes("image-set(") ||
-    normalized.includes("cross-fade(") ||
-    normalized.includes("element(") ||
-    normalized.includes("paint(")
+    indexOfAsciiIgnoreCase(value, "image(") !== -1 ||
+    indexOfAsciiIgnoreCase(value, "image-set(") !== -1 ||
+    indexOfAsciiIgnoreCase(value, "cross-fade(") !== -1 ||
+    indexOfAsciiIgnoreCase(value, "element(") !== -1 ||
+    indexOfAsciiIgnoreCase(value, "paint(") !== -1
   ) {
     return false;
   }
   let cursor = 0;
   while (true) {
-    const start = normalized.indexOf("url(", cursor);
+    const start = indexOfAsciiIgnoreCase(value, "url(", cursor);
     if (start === -1) return true;
 
     const end = value.indexOf(")", start + 4);
@@ -77,12 +96,71 @@ function isSafeSvgReference(value: string): boolean {
   return value.trim().startsWith("#");
 }
 
-function removeOpaqueNodes(node: Node): void {
-  for (const child of Array.from(node.childNodes)) {
-    if (child.nodeType !== 1 && child.nodeType !== 3) {
-      child.remove();
+function isWithinSvgDepthLimit(input: string): boolean {
+  let depth = 0;
+  for (let index = 0; index < input.length; index += 1) {
+    if (input[index] !== "<") continue;
+
+    if (input.startsWith("<!--", index)) {
+      const end = input.indexOf("-->", index + 4);
+      if (end === -1) return false;
+      index = end + 2;
+      continue;
+    }
+    if (input.startsWith("<![CDATA[", index)) {
+      const end = input.indexOf("]]>", index + 9);
+      if (end === -1) return false;
+      index = end + 2;
+      continue;
+    }
+    if (input.startsWith("<?", index)) {
+      const end = input.indexOf("?>", index + 2);
+      if (end === -1) return false;
+      index = end + 1;
+      continue;
+    }
+    if (input.startsWith("<!", index)) return false;
+
+    const isClosing = input[index + 1] === "/";
+    let quote: string | null = null;
+    let end = index + (isClosing ? 2 : 1);
+    for (; end < input.length; end += 1) {
+      const character = input[end]!;
+      if (quote) {
+        if (character === quote) quote = null;
+      } else if (character === "'" || character === '"') {
+        quote = character;
+      } else if (character === ">") {
+        break;
+      }
+    }
+    if (end === input.length || quote) return false;
+
+    if (isClosing) {
+      depth -= 1;
+      if (depth < 0) return false;
     } else {
-      removeOpaqueNodes(child);
+      const isSelfClosing = /\/\s*$/.test(input.slice(index + 1, end));
+      if (!isSelfClosing) {
+        depth += 1;
+        if (depth > MAX_SVG_DEPTH) return false;
+      }
+    }
+    index = end;
+  }
+  return true;
+}
+
+function removeOpaqueNodes(node: Node): void {
+  const stack: Node[] = [node];
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    for (const child of Array.from(current.childNodes)) {
+      if (child.nodeType !== 1 && child.nodeType !== 3) {
+        child.remove();
+      } else if (child.nodeType === 1) {
+        stack.push(child);
+      }
     }
   }
 }
@@ -139,6 +217,9 @@ export function validateSvg(input: string): { ok: true; svg: string } | { ok: fa
   if (trimmed.length > MAX_SVG_SIZE) {
     return { ok: false, error: "SVG exceeds the 1 MB size limit" };
   }
+  if (!isWithinSvgDepthLimit(trimmed)) {
+    return { ok: false, error: "SVG exceeds the nesting-depth limit" };
+  }
   if (typeof DOMParser === "undefined" || typeof XMLSerializer === "undefined") {
     return { ok: false, error: "SVG validation is unavailable in this environment" };
   }
@@ -180,11 +261,10 @@ export function validateSvg(input: string): { ok: true; svg: string } | { ok: fa
       const isUrlAttribute = name === "href" || name === "xlink:href" || name === "src";
       if (
         name.startsWith("on") ||
-        name === "style" ||
-        name === "srcset" ||
+        FORBIDDEN_SVG_ATTRIBUTES.has(name) ||
         value.includes("\\") ||
         (isUrlAttribute && !isSafeSvgReference(value)) ||
-        !hasOnlyLocalUrlReferences(value)
+        (CSS_URL_ATTRIBUTES.has(name) && !hasOnlyLocalUrlReferences(value))
       ) {
         element.removeAttribute(attribute.name);
       }

--- a/apps/dashboard/shared/src/floorplan.ts
+++ b/apps/dashboard/shared/src/floorplan.ts
@@ -63,6 +63,16 @@ function isSafeSvgReference(value: string): boolean {
   return value.trim().startsWith("#");
 }
 
+function removeComments(node: Node): void {
+  for (const child of Array.from(node.childNodes)) {
+    if (child.nodeType === 7 || child.nodeType === 8) {
+      child.remove();
+    } else {
+      removeComments(child);
+    }
+  }
+}
+
 export function normalizeFloorplan(raw: unknown): FloorplanData {
   if (raw == null || typeof raw !== "object") return EMPTY_FLOORPLAN;
   const obj = raw as Record<string, unknown>;
@@ -126,7 +136,10 @@ export function validateSvg(input: string): { ok: true; svg: string } | { ok: fa
   if (svgDocument.doctype) {
     return { ok: false, error: "SVG document types are not allowed" };
   }
-  if (svgDocument.documentElement?.localName.toLowerCase() !== "svg") {
+  if (
+    svgDocument.documentElement?.localName.toLowerCase() !== "svg" ||
+    svgDocument.documentElement.prefix
+  ) {
     return { ok: false, error: "document root must be <svg>" };
   }
 
@@ -137,7 +150,7 @@ export function validateSvg(input: string): { ok: true; svg: string } | { ok: fa
 
   let attributeCount = 0;
   for (const element of elements) {
-    if (UNSAFE_SVG_ELEMENTS.has(element.localName.toLowerCase())) {
+    if (element.prefix || UNSAFE_SVG_ELEMENTS.has(element.localName.toLowerCase())) {
       element.remove();
       continue;
     }
@@ -150,7 +163,7 @@ export function validateSvg(input: string): { ok: true; svg: string } | { ok: fa
 
       const name = attribute.name.toLowerCase();
       const value = attribute.value.trim();
-      const isUrlAttribute = name === "href" || name === "xlink:href" || name === "src";
+      const isUrlAttribute = name === "href" || name === "xlink:href" || name === "src" || name === "srcset";
       if (
         name.startsWith("on") ||
         name === "style" ||
@@ -163,6 +176,7 @@ export function validateSvg(input: string): { ok: true; svg: string } | { ok: fa
     }
   }
 
+  removeComments(svgDocument);
   const svg = new XMLSerializer().serializeToString(svgDocument.documentElement);
   if (svg.length > MAX_SVG_SIZE) {
     return { ok: false, error: "SVG exceeds the 1 MB size limit after parsing" };

--- a/apps/dashboard/shared/src/floorplan.ts
+++ b/apps/dashboard/shared/src/floorplan.ts
@@ -41,11 +41,22 @@ const UNSAFE_SVG_ELEMENTS = new Set([
 ]);
 
 function hasOnlyLocalUrlReferences(value: string): boolean {
-  const matches = value.matchAll(/url\(\s*(['"]?)(.*?)\1\s*\)/gi);
-  for (const match of matches) {
-    if (!(match[2] ?? "").trim().startsWith("#")) return false;
+  const normalized = value.toLowerCase();
+  let cursor = 0;
+  while (true) {
+    const start = normalized.indexOf("url(", cursor);
+    if (start === -1) return true;
+
+    const end = value.indexOf(")", start + 4);
+    if (end === -1) return false;
+    let reference = value.slice(start + 4, end).trim();
+    const quote = reference[0];
+    if ((quote === "'" || quote === '"') && reference.endsWith(quote)) {
+      reference = reference.slice(1, -1).trim();
+    }
+    if (!reference.startsWith("#")) return false;
+    cursor = end + 1;
   }
-  return true;
 }
 
 function isSafeSvgReference(value: string): boolean {
@@ -112,6 +123,9 @@ export function validateSvg(input: string): { ok: true; svg: string } | { ok: fa
   if (svgDocument.querySelector("parsererror")) {
     return { ok: false, error: "SVG is not valid XML" };
   }
+  if (svgDocument.doctype) {
+    return { ok: false, error: "SVG document types are not allowed" };
+  }
   if (svgDocument.documentElement?.localName.toLowerCase() !== "svg") {
     return { ok: false, error: "document root must be <svg>" };
   }
@@ -140,6 +154,7 @@ export function validateSvg(input: string): { ok: true; svg: string } | { ok: fa
       if (
         name.startsWith("on") ||
         name === "style" ||
+        value.includes("\\") ||
         (isUrlAttribute && !isSafeSvgReference(value)) ||
         !hasOnlyLocalUrlReferences(value)
       ) {
@@ -148,7 +163,11 @@ export function validateSvg(input: string): { ok: true; svg: string } | { ok: fa
     }
   }
 
-  return { ok: true, svg: new XMLSerializer().serializeToString(svgDocument.documentElement) };
+  const svg = new XMLSerializer().serializeToString(svgDocument.documentElement);
+  if (svg.length > MAX_SVG_SIZE) {
+    return { ok: false, error: "SVG exceeds the 1 MB size limit after parsing" };
+  }
+  return { ok: true, svg };
 }
 
 /**

--- a/apps/dashboard/shared/src/floorplan.ts
+++ b/apps/dashboard/shared/src/floorplan.ts
@@ -46,7 +46,7 @@ const SAFE_SVG_ELEMENTS = new Set([
   "fepointlight", "fespecularlighting", "fespotlight", "fetile", "feturbulence", "image", "a",
 ]);
 const CSS_URL_ATTRIBUTES = new Set([
-  "fill", "stroke", "filter", "clip-path", "mask", "marker-start", "marker-mid", "marker-end", "cursor",
+  "fill", "stroke", "filter", "clip-path", "mask", "marker", "marker-start", "marker-mid", "marker-end", "cursor",
 ]);
 const FORBIDDEN_SVG_ATTRIBUTES = new Set([
   "base", "xml:base", "style", "srcset", "mask-image", "background", "background-image", "border-image",
@@ -259,12 +259,12 @@ export function validateSvg(input: string): { ok: true; svg: string } | { ok: fa
       const name = attribute.name.toLowerCase();
       const value = attribute.value.trim();
       const isUrlAttribute = name === "href" || name === "xlink:href" || name === "src";
+      const isCssUrlAttribute = CSS_URL_ATTRIBUTES.has(name);
       if (
         name.startsWith("on") ||
         FORBIDDEN_SVG_ATTRIBUTES.has(name) ||
-        value.includes("\\") ||
         (isUrlAttribute && !isSafeSvgReference(value)) ||
-        (CSS_URL_ATTRIBUTES.has(name) && !hasOnlyLocalUrlReferences(value))
+        (isCssUrlAttribute && (value.includes("\\") || !hasOnlyLocalUrlReferences(value)))
       ) {
         element.removeAttribute(attribute.name);
       }

--- a/apps/dashboard/shared/src/floorplan.ts
+++ b/apps/dashboard/shared/src/floorplan.ts
@@ -38,7 +38,7 @@ const MAX_SVG_ATTRIBUTES = 50_000;
 const MAX_SVG_DEPTH = 256;
 const SAFE_SVG_ELEMENTS = new Set([
   "svg", "g", "defs", "view", "switch", "path", "rect", "circle", "ellipse", "line",
-  "polyline", "polygon", "text", "tspan", "textpath", "use", "symbol", "marker", "pattern",
+  "polyline", "polygon", "text", "tspan", "textpath", "symbol", "marker", "pattern",
   "clippath", "mask", "lineargradient", "radialgradient", "stop", "filter", "feblend",
   "fecolormatrix", "fecomponenttransfer", "fecomposite", "feconvolvematrix", "fediffuselighting",
   "fedisplacementmap", "fedistantlight", "fedropshadow", "feflood", "fefunca", "fefuncb", "fefuncg",
@@ -49,7 +49,7 @@ const CSS_URL_ATTRIBUTES = new Set([
   "fill", "stroke", "filter", "clip-path", "mask", "marker", "marker-start", "marker-mid", "marker-end", "cursor",
 ]);
 const FORBIDDEN_SVG_ATTRIBUTES = new Set([
-  "base", "xml:base", "style", "srcset", "mask-image", "background", "background-image", "border-image",
+  "base", "xml:base", "style", "class", "srcset", "mask-image", "background", "background-image", "border-image",
   "content", "list-style-image", "poster", "shape-outside",
 ]);
 
@@ -301,12 +301,13 @@ export function extractFloors(svg: string): string[] {
  * is null or the SVG has no data-floor groups, returns the input unchanged.
  */
 export function filterFloors(svg: string, visibleFloors: Set<string> | null): string {
-  if (!visibleFloors) return svg;
-  const floors = extractFloors(svg);
-  if (floors.length === 0) return svg;
-  // Remove any <g data-floor="X">...</g> whose X isn't in visibleFloors.
-  // Need balanced tag matching since groups can contain nested groups.
-  return removeFloorsExcept(svg, visibleFloors);
+  if (!visibleFloors || typeof DOMParser === "undefined" || typeof XMLSerializer === "undefined") return svg;
+  const document = new DOMParser().parseFromString(svg, "image/svg+xml");
+  if (document.querySelector("parsererror")) return svg;
+  for (const group of Array.from(document.querySelectorAll("g[data-floor]"))) {
+    if (!visibleFloors.has(group.getAttribute("data-floor") ?? "")) group.remove();
+  }
+  return new XMLSerializer().serializeToString(document.documentElement);
 }
 
 export interface RoomGeometry {
@@ -389,42 +390,3 @@ export function getViewBox(svg: string): string {
   return m ? m[1]! : "0 0 100 70";
 }
 
-function removeFloorsExcept(svg: string, keep: Set<string>): string {
-  let out = svg;
-  const openRegex = /<g\b[^>]*\bdata-floor\s*=\s*"([^"]*)"[^>]*>/i;
-  while (true) {
-    const open = openRegex.exec(out);
-    if (!open) break;
-    const name = open[1] ?? "";
-    const startIdx = open.index;
-    const headerEnd = startIdx + open[0].length;
-    const isSelfClosing = /\/\s*>$/.test(open[0]);
-    if (keep.has(name)) {
-      // Replace the attribute so we don't re-match, but keep the group.
-      const replaced = open[0].replace(/data-floor="[^"]*"/i, `data-floor-kept="${name}"`);
-      out = out.slice(0, startIdx) + replaced + out.slice(headerEnd);
-      continue;
-    }
-    if (isSelfClosing) {
-      out = out.slice(0, startIdx) + out.slice(headerEnd);
-      continue;
-    }
-    // Find the matching </g> by counting nesting depth.
-    let depth = 1;
-    let i = headerEnd;
-    const tagRegex = /<g\b[^>]*\/?>|<\/g\s*>/gi;
-    tagRegex.lastIndex = headerEnd;
-    let tag: RegExpExecArray | null;
-    while ((tag = tagRegex.exec(out)) !== null && depth > 0) {
-      if (tag[0].startsWith("</")) {
-        depth--;
-      } else if (!/\/\s*>$/.test(tag[0])) {
-        depth++;
-      }
-      i = tagRegex.lastIndex;
-    }
-    out = out.slice(0, startIdx) + out.slice(i);
-  }
-  // Restore the marker attribute name we used to skip the kept groups.
-  return out.replace(/data-floor-kept=/gi, "data-floor=");
-}

--- a/apps/dashboard/shared/src/floorplan.ts
+++ b/apps/dashboard/shared/src/floorplan.ts
@@ -389,4 +389,3 @@ export function getViewBox(svg: string): string {
   const m = /<svg\b[^>]*\bviewBox\s*=\s*"([^"]*)"/i.exec(svg);
   return m ? m[1]! : "0 0 100 70";
 }
-

--- a/apps/dashboard/shared/test/floorplan-sanitizer.ts
+++ b/apps/dashboard/shared/test/floorplan-sanitizer.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
-import { normalizeFloorplan, validateSvg } from "../src/floorplan.js";
+import { filterFloors, normalizeFloorplan, validateSvg } from "../src/floorplan.js";
 
 const window = new JSDOM().window;
 Object.assign(globalThis, {
@@ -31,6 +31,7 @@ const hostile = sanitized(`
     <image href="https://attacker.example/pixel.svg"/>
     <img srcset="https://attacker.example/pixel 1x"/>
     <p><video poster="https://attacker.example/poster"/></p>
+    <rect mask-image="image-set('https://attacker.example/mask.png' 1x)"/>
     <use href="javascript:alert(1)"/>
     <rect style="fill: url(data:image/svg+xml,evil)" fill="url(https://attacker.example/paint)" stroke="u\\rl(https://attacker.example/escaped)"/>
   </svg>
@@ -43,6 +44,17 @@ assert.doesNotMatch(commented, /<!--|https:/, "comments cannot be reactivated by
 
 const cdata = sanitized(`<svg><g data-floor="bad"><![CDATA[</g><image href="https://attacker.example/pixel"/>]]></g></svg>`);
 assert.doesNotMatch(cdata, /<!\[CDATA|https:/, "CDATA cannot be reactivated by floor filtering");
+
+const titleIntegrationPoint = sanitized(`<svg><title><image srcset="#local 1x, https://attacker.example/pixel 2x"/></title></svg>`);
+assert.doesNotMatch(titleIntegrationPoint, /<title\b|srcset=|https:/, "integration-point content is removed");
+
+const floorSvg = sanitized(`<svg><g data-floor="hidden"></g><g data-floor="visible"><rect/></g></svg>`);
+const filteredFloors = filterFloors(floorSvg, new Set(["visible"]));
+assert.doesNotMatch(filteredFloors, /data-floor="hidden"/);
+assert.match(filteredFloors, /data-floor="visible"/, "self-closing hidden groups do not remove visible floors");
+
+const withSwitch = sanitized(`<svg><switch><g data-floor="Main"><rect data-zone="zone"/></g></switch></svg>`);
+assert.match(withSwitch, /<switch\b/i, "standard SVG switch containers are retained");
 
 const stored = normalizeFloorplan({ svg: `<svg><script>alert(1)</script><rect/></svg>`, placements: [] });
 assert.doesNotMatch(stored.svg, /<script\b/i, "stored SVG is sanitized before rendering");

--- a/apps/dashboard/shared/test/floorplan-sanitizer.ts
+++ b/apps/dashboard/shared/test/floorplan-sanitizer.ts
@@ -27,6 +27,9 @@ assert.match(safe, /href="#room-symbol"/);
 const namedFloor = sanitized(`<svg><g data-floor="Image(s)"><rect/></g></svg>`);
 assert.match(namedFloor, /data-floor="Image\(s\)"/, "non-CSS metadata values are preserved");
 
+const escapedFloor = sanitized(`<svg><g data-floor="North\\South"><rect/></g></svg>`);
+assert.ok(escapedFloor.includes('data-floor="North\\South"'), "metadata escapes are preserved");
+
 const hostile = sanitized(`
   <svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)">
     <script>alert(1)</script>
@@ -48,6 +51,9 @@ assert.doesNotMatch(basedReference, /xml:base|https:/i, "base URLs cannot turn f
 const unicodePrefix = "İ".repeat(30);
 const unicodeUrl = sanitized(`<svg><rect fill="/*${unicodePrefix}*/url(https://attacker.example/p.svg#x)"/></svg>`);
 assert.doesNotMatch(unicodeUrl, /fill=|https:/i, "URL scanning retains original string offsets");
+
+const markerReference = sanitized(`<svg><path marker="url(https://attacker.example/marker.svg#x)"/></svg>`);
+assert.doesNotMatch(markerReference, /marker=|https:/i, "marker shorthand cannot use remote URLs");
 
 const commented = sanitized(`<svg><g data-floor="bad"><!--</g><image href="https://attacker.example/pixel"/>--></g></svg>`);
 assert.doesNotMatch(commented, /<!--|https:/, "comments cannot be reactivated by floor filtering");

--- a/apps/dashboard/shared/test/floorplan-sanitizer.ts
+++ b/apps/dashboard/shared/test/floorplan-sanitizer.ts
@@ -29,18 +29,23 @@ const hostile = sanitized(`
     <script>alert(1)</script>
     <foreignObject><img src="x" onerror="alert(1)"/></foreignObject>
     <image href="https://attacker.example/pixel.svg"/>
+    <img srcset="https://attacker.example/pixel 1x"/>
     <use href="javascript:alert(1)"/>
     <rect style="fill: url(data:image/svg+xml,evil)" fill="url(https://attacker.example/paint)" stroke="u\\rl(https://attacker.example/escaped)"/>
   </svg>
 `);
 assert.doesNotMatch(hostile, /<script\b|<foreignobject\b|onload=|onerror=/i);
-assert.doesNotMatch(hostile, /https:|javascript:|data:|style=/i);
+assert.doesNotMatch(hostile, /https:|javascript:|data:|style=|srcset=/i);
+
+const commented = sanitized(`<svg><g data-floor="bad"><!--</g><image href="https://attacker.example/pixel"/>--></g></svg>`);
+assert.doesNotMatch(commented, /<!--|https:/, "comments cannot be reactivated by floor filtering");
 
 const stored = normalizeFloorplan({ svg: `<svg><script>alert(1)</script><rect/></svg>`, placements: [] });
 assert.doesNotMatch(stored.svg, /<script\b/i, "stored SVG is sanitized before rendering");
 
 assert.equal(validateSvg("<svg><rect></svg>").ok, false, "malformed XML is rejected");
 assert.equal(validateSvg("<html></html>").ok, false, "non-SVG roots are rejected");
+assert.equal(validateSvg("<s:svg xmlns:s=\"http://www.w3.org/2000/svg\"><s:rect/></s:svg>").ok, false, "prefixed SVG roots are rejected");
 assert.equal(validateSvg("<!DOCTYPE svg [<!ENTITY x 'large'>]><svg>&x;</svg>").ok, false, "document types are rejected");
 assert.doesNotMatch(
   sanitized(`<svg><rect fill="${"url(".repeat(40_000)}"/></svg>`),

--- a/apps/dashboard/shared/test/floorplan-sanitizer.ts
+++ b/apps/dashboard/shared/test/floorplan-sanitizer.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { Window } from "happy-dom";
+import { normalizeFloorplan, validateSvg } from "../src/floorplan.js";
+
+const window = new Window();
+Object.assign(globalThis, {
+  DOMParser: window.DOMParser,
+  XMLSerializer: window.XMLSerializer,
+});
+
+function sanitized(input: string): string {
+  const result = validateSvg(input);
+  assert.equal(result.ok, true, result.ok ? undefined : result.error);
+  return result.svg;
+}
+
+const safe = sanitized(`
+  <svg xmlns="http://www.w3.org/2000/svg">
+    <defs><linearGradient id="shade"><stop offset="0"/></linearGradient></defs>
+    <rect fill="url(#shade)"/>
+    <use href="#room-symbol"/>
+  </svg>
+`);
+assert.match(safe, /fill="url\(#shade\)"/);
+assert.match(safe, /href="#room-symbol"/);
+
+const hostile = sanitized(`
+  <svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)">
+    <script>alert(1)</script>
+    <foreignObject><img src="x" onerror="alert(1)"/></foreignObject>
+    <image href="https://attacker.example/pixel.svg"/>
+    <use href="javascript:alert(1)"/>
+    <rect style="fill: url(data:image/svg+xml,evil)" fill="url(https://attacker.example/paint)"/>
+  </svg>
+`);
+assert.doesNotMatch(hostile, /<script\b|<foreignobject\b|onload=|onerror=/i);
+assert.doesNotMatch(hostile, /https:|javascript:|data:|style=/i);
+
+const stored = normalizeFloorplan({ svg: `<svg><script>alert(1)</script><rect/></svg>`, placements: [] });
+assert.doesNotMatch(stored.svg, /<script\b/i, "stored SVG is sanitized before rendering");
+
+assert.equal(validateSvg("<svg><rect></svg>").ok, false, "malformed XML is rejected");
+assert.equal(validateSvg("<html></html>").ok, false, "non-SVG roots are rejected");
+assert.equal(validateSvg(`<svg>${"<g/>".repeat(10_001)}</svg>`).ok, false, "element limit is enforced");
+
+console.log("OK — floorplan SVG sanitizer assertions passed");

--- a/apps/dashboard/shared/test/floorplan-sanitizer.ts
+++ b/apps/dashboard/shared/test/floorplan-sanitizer.ts
@@ -30,15 +30,19 @@ const hostile = sanitized(`
     <foreignObject><img src="x" onerror="alert(1)"/></foreignObject>
     <image href="https://attacker.example/pixel.svg"/>
     <img srcset="https://attacker.example/pixel 1x"/>
+    <p><video poster="https://attacker.example/poster"/></p>
     <use href="javascript:alert(1)"/>
     <rect style="fill: url(data:image/svg+xml,evil)" fill="url(https://attacker.example/paint)" stroke="u\\rl(https://attacker.example/escaped)"/>
   </svg>
 `);
-assert.doesNotMatch(hostile, /<script\b|<foreignobject\b|onload=|onerror=/i);
+assert.doesNotMatch(hostile, /<script\b|<foreignobject\b|<img\b|<p\b|<video\b|onload=|onerror=/i);
 assert.doesNotMatch(hostile, /https:|javascript:|data:|style=|srcset=/i);
 
 const commented = sanitized(`<svg><g data-floor="bad"><!--</g><image href="https://attacker.example/pixel"/>--></g></svg>`);
 assert.doesNotMatch(commented, /<!--|https:/, "comments cannot be reactivated by floor filtering");
+
+const cdata = sanitized(`<svg><g data-floor="bad"><![CDATA[</g><image href="https://attacker.example/pixel"/>]]></g></svg>`);
+assert.doesNotMatch(cdata, /<!\[CDATA|https:/, "CDATA cannot be reactivated by floor filtering");
 
 const stored = normalizeFloorplan({ svg: `<svg><script>alert(1)</script><rect/></svg>`, placements: [] });
 assert.doesNotMatch(stored.svg, /<script\b/i, "stored SVG is sanitized before rendering");

--- a/apps/dashboard/shared/test/floorplan-sanitizer.ts
+++ b/apps/dashboard/shared/test/floorplan-sanitizer.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
-import { Window } from "happy-dom";
+import { JSDOM } from "jsdom";
 import { normalizeFloorplan, validateSvg } from "../src/floorplan.js";
 
-const window = new Window();
+const window = new JSDOM().window;
 Object.assign(globalThis, {
   DOMParser: window.DOMParser,
   XMLSerializer: window.XMLSerializer,
@@ -30,7 +30,7 @@ const hostile = sanitized(`
     <foreignObject><img src="x" onerror="alert(1)"/></foreignObject>
     <image href="https://attacker.example/pixel.svg"/>
     <use href="javascript:alert(1)"/>
-    <rect style="fill: url(data:image/svg+xml,evil)" fill="url(https://attacker.example/paint)"/>
+    <rect style="fill: url(data:image/svg+xml,evil)" fill="url(https://attacker.example/paint)" stroke="u\\rl(https://attacker.example/escaped)"/>
   </svg>
 `);
 assert.doesNotMatch(hostile, /<script\b|<foreignobject\b|onload=|onerror=/i);
@@ -41,6 +41,12 @@ assert.doesNotMatch(stored.svg, /<script\b/i, "stored SVG is sanitized before re
 
 assert.equal(validateSvg("<svg><rect></svg>").ok, false, "malformed XML is rejected");
 assert.equal(validateSvg("<html></html>").ok, false, "non-SVG roots are rejected");
+assert.equal(validateSvg("<!DOCTYPE svg [<!ENTITY x 'large'>]><svg>&x;</svg>").ok, false, "document types are rejected");
+assert.doesNotMatch(
+  sanitized(`<svg><rect fill="${"url(".repeat(40_000)}"/></svg>`),
+  /fill=/,
+  "unterminated URL functions are removed without regex backtracking",
+);
 assert.equal(validateSvg(`<svg>${"<g/>".repeat(10_001)}</svg>`).ok, false, "element limit is enforced");
 
 console.log("OK — floorplan SVG sanitizer assertions passed");

--- a/apps/dashboard/shared/test/floorplan-sanitizer.ts
+++ b/apps/dashboard/shared/test/floorplan-sanitizer.ts
@@ -22,7 +22,7 @@ const safe = sanitized(`
   </svg>
 `);
 assert.match(safe, /fill="url\(#shade\)"/);
-assert.match(safe, /href="#room-symbol"/);
+assert.doesNotMatch(safe, /<use\b/i, "use elements are removed to prevent recursive expansion");
 
 const namedFloor = sanitized(`<svg><g data-floor="Image(s)"><rect/></g></svg>`);
 assert.match(namedFloor, /data-floor="Image\(s\)"/, "non-CSS metadata values are preserved");
@@ -71,6 +71,9 @@ assert.match(filteredFloors, /data-floor="visible"/, "self-closing hidden groups
 
 const withSwitch = sanitized(`<svg><switch><g data-floor="Main"><rect data-zone="zone"/></g></switch></svg>`);
 assert.match(withSwitch, /<switch\b/i, "standard SVG switch containers are retained");
+
+const styledRoot = sanitized(`<svg class="modal-backdrop"><rect/></svg>`);
+assert.doesNotMatch(styledRoot, /class=/, "imported classes cannot apply dashboard styles");
 
 assert.equal(
   validateSvg(`<svg>${"<g>".repeat(8_000)}${"</g>".repeat(8_000)}</svg>`).ok,

--- a/apps/dashboard/shared/test/floorplan-sanitizer.ts
+++ b/apps/dashboard/shared/test/floorplan-sanitizer.ts
@@ -24,6 +24,9 @@ const safe = sanitized(`
 assert.match(safe, /fill="url\(#shade\)"/);
 assert.match(safe, /href="#room-symbol"/);
 
+const namedFloor = sanitized(`<svg><g data-floor="Image(s)"><rect/></g></svg>`);
+assert.match(namedFloor, /data-floor="Image\(s\)"/, "non-CSS metadata values are preserved");
+
 const hostile = sanitized(`
   <svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)">
     <script>alert(1)</script>
@@ -38,6 +41,13 @@ const hostile = sanitized(`
 `);
 assert.doesNotMatch(hostile, /<script\b|<foreignobject\b|<img\b|<p\b|<video\b|onload=|onerror=/i);
 assert.doesNotMatch(hostile, /https:|javascript:|data:|style=|srcset=/i);
+
+const basedReference = sanitized(`<svg><image xml:base="https://attacker.example/p.svg" href="#pixel"/></svg>`);
+assert.doesNotMatch(basedReference, /xml:base|https:/i, "base URLs cannot turn fragments into remote references");
+
+const unicodePrefix = "İ".repeat(30);
+const unicodeUrl = sanitized(`<svg><rect fill="/*${unicodePrefix}*/url(https://attacker.example/p.svg#x)"/></svg>`);
+assert.doesNotMatch(unicodeUrl, /fill=|https:/i, "URL scanning retains original string offsets");
 
 const commented = sanitized(`<svg><g data-floor="bad"><!--</g><image href="https://attacker.example/pixel"/>--></g></svg>`);
 assert.doesNotMatch(commented, /<!--|https:/, "comments cannot be reactivated by floor filtering");
@@ -55,6 +65,12 @@ assert.match(filteredFloors, /data-floor="visible"/, "self-closing hidden groups
 
 const withSwitch = sanitized(`<svg><switch><g data-floor="Main"><rect data-zone="zone"/></g></switch></svg>`);
 assert.match(withSwitch, /<switch\b/i, "standard SVG switch containers are retained");
+
+assert.equal(
+  validateSvg(`<svg>${"<g>".repeat(8_000)}${"</g>".repeat(8_000)}</svg>`).ok,
+  false,
+  "excessive nesting is rejected before DOM parsing",
+);
 
 const stored = normalizeFloorplan({ svg: `<svg><script>alert(1)</script><rect/></svg>`, placements: [] });
 assert.doesNotMatch(stored.svg, /<script\b/i, "stored SVG is sanitized before rendering");

--- a/apps/dashboard/src/components/Floorplan.tsx
+++ b/apps/dashboard/src/components/Floorplan.tsx
@@ -167,7 +167,7 @@ export function Floorplan({
   const visibleFloors =
     floors.length > 0 ? new Set(floors.filter((f) => !hiddenFloors.has(f))) : null;
   const renderedSvg =
-    data.svg && visibleFloors ? filterFloors(data.svg, visibleFloors) : data.svg;
+    data.svg && visibleFloors && hiddenFloors.size > 0 ? filterFloors(data.svg, visibleFloors) : data.svg;
   const viewBox = data.svg ? getViewBox(data.svg) : "0 0 100 70";
 
   // Compute effective placements: persisted (devices + flows), plus


### PR DESCRIPTION
Closes #13

- Parse and sanitize imported and persisted SVG before rendering
- Remove executable elements, event attributes and non-local resource references
- Add input-complexity limits and security regression tests

Verified with `npm run typecheck && npm run test:floorplan` in `apps/dashboard/shared` and `npm run build` in `apps/dashboard`.