### PR TITLE
Add structured issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -1,0 +1,60 @@
+name: Bug report
+description: Report a reproducible problem in Smart (Components) Toolkit.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for helping improve the project. Please search existing issues before submitting a new report.
+  - type: checkboxes
+    id: searched
+    attributes:
+      label: Existing reports
+      options:
+        - label: I have searched the existing issues for duplicates.
+          required: true
+  - type: input
+    id: app-version
+    attributes:
+      label: Smart (Components) Toolkit version
+      description: Find this in Homey under Apps.
+      placeholder: "For example, 1.10.26"
+    validations:
+      required: true
+  - type: input
+    id: homey
+    attributes:
+      label: Homey model and firmware version
+      placeholder: "For example, Homey Pro (Early 2023), 12.7.1"
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide the smallest sequence that consistently shows the problem.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include any visible error message.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs, Flow cards, or screenshots
+      description: Remove tokens, passwords, device IDs, and other private information before posting.

--- a/.github/ISSUE_TEMPLATE/02-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature-request.yml
@@ -1,0 +1,40 @@
+name: Feature request
+description: Propose an improvement to Smart (Components) Toolkit.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for the suggestion. A concrete use case makes it much easier to evaluate.
+  - type: checkboxes
+    id: searched
+    attributes:
+      label: Existing requests
+      options:
+        - label: I have searched the existing issues for similar requests.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What are you trying to accomplish, and why is the current behavior insufficient?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the outcome rather than only the implementation.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives or workarounds
+      description: What have you tried already?
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Mockups, Flow examples, or screenshots are welcome. Remove private data first.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
Closes #33

- Add guided bug-report and feature-request forms
- Require core reproduction or use-case details
- Disable blank issues for external contributors