### PR TITLE
Store dashboard OAuth state in the OS credential store

### DIFF
--- a/apps/dashboard/shared/package.json
+++ b/apps/dashboard/shared/package.json
@@ -8,7 +8,9 @@
   "types": "./src/index.ts",
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "test:floorplan": "tsx test/floorplan-sanitizer.ts"
+    "test:smoke": "tsx test/smoke.ts",
+    "test:floorplan": "tsx test/floorplan-sanitizer.ts",
+    "test:legacy-auth-storage": "tsx test/legacy-auth-storage.ts"
   },
   "devDependencies": {
     "jsdom": "^26.1.0",

--- a/apps/dashboard/shared/src/auth.ts
+++ b/apps/dashboard/shared/src/auth.ts
@@ -1,4 +1,9 @@
-import type { AthomCloudAPICtor, AthomCloudAPILike, AuthCredentials } from "./types.js";
+import type {
+  AthomCloudAPICtor,
+  AthomCloudAPILike,
+  AthomStorageAdapter,
+  AuthCredentials,
+} from "./types.js";
 
 const ATHOM_AUTHORIZE = "https://api.athom.com/oauth2/authorise";
 
@@ -21,6 +26,7 @@ export function buildAuthorizeUrl(creds: AuthCredentials, state?: string): strin
 export interface AuthSessionOpts {
   AthomCloudAPI: AthomCloudAPICtor;
   credentials: AuthCredentials;
+  store?: AthomStorageAdapter;
 }
 
 export class AuthSession {
@@ -28,7 +34,7 @@ export class AuthSession {
   private readonly creds: AuthCredentials;
 
   constructor(opts: AuthSessionOpts) {
-    this.cloud = new opts.AthomCloudAPI(opts.credentials);
+    this.cloud = new opts.AthomCloudAPI({ ...opts.credentials, store: opts.store });
     this.creds = opts.credentials;
   }
 

--- a/apps/dashboard/shared/src/types.ts
+++ b/apps/dashboard/shared/src/types.ts
@@ -34,6 +34,12 @@ export interface TokenStorage {
   clear(): Promise<void>;
 }
 
+/** Persistence interface consumed by AthomCloudAPI for its OAuth token and user cache. */
+export interface AthomStorageAdapter {
+  get(): Promise<object>;
+  set(value: object): Promise<void>;
+}
+
 export interface AthomCloudAPILike {
   isLoggedIn(): Promise<boolean>;
   authenticateWithAuthorizationCode(opts: { code: string; redirectUrl: string }): Promise<unknown>;
@@ -151,4 +157,7 @@ export interface RawFlowFolder {
   parent?: string | null;
 }
 
-export type AthomCloudAPICtor = new (opts: AuthCredentials) => AthomCloudAPILike;
+export interface AthomCloudAPICtor {
+  new (opts: AuthCredentials & { store?: AthomStorageAdapter }): AthomCloudAPILike;
+  StorageAdapter: new () => AthomStorageAdapter;
+}

--- a/apps/dashboard/shared/test/legacy-auth-storage.ts
+++ b/apps/dashboard/shared/test/legacy-auth-storage.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import {
+  LEGACY_CLOUD_STORE_KEY,
+  LEGACY_CREDENTIAL_KEYS,
+  hasLegacySensitiveStorage,
+  legacySensitiveKeys,
+  migrateLegacyAuth,
+  type LegacyStorage,
+} from "../../src/lib/legacy-auth-storage.js";
+
+class MemoryStorage implements LegacyStorage {
+  private readonly values = new Map<string, string>();
+
+  get length() {
+    return this.values.size;
+  }
+
+  key(index: number) {
+    return [...this.values.keys()][index] ?? null;
+  }
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null;
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value);
+  }
+}
+
+const storage = new MemoryStorage();
+storage.setItem(LEGACY_CREDENTIAL_KEYS.clientId, "client-id");
+storage.setItem(LEGACY_CREDENTIAL_KEYS.clientSecret, "client-secret");
+storage.setItem(LEGACY_CLOUD_STORE_KEY, '{"token":{"access_token":"secret"}}');
+storage.setItem("athom_session", "secret");
+storage.setItem("homey_dashboard_favorites", '["safe-public-preference"]');
+
+assert.deepEqual(
+  new Set(legacySensitiveKeys(storage)),
+  new Set([
+    LEGACY_CREDENTIAL_KEYS.clientId,
+    LEGACY_CREDENTIAL_KEYS.clientSecret,
+    LEGACY_CLOUD_STORE_KEY,
+    "homey_api_key",
+    "homey_access_token",
+    "homey_refresh_token",
+    "athom_access_token",
+    "athom_refresh_token",
+    "athom_token_expires_at",
+    "athom_session",
+  ]),
+);
+assert.equal(hasLegacySensitiveStorage(storage), true);
+
+let savedCredentials: { clientId: string; clientSecret: string } | undefined;
+let savedCloudStore: string | undefined;
+await migrateLegacyAuth(storage, {
+  saveCredentials: async (credentials) => {
+    savedCredentials = credentials;
+  },
+  loadCloudStore: async () => null,
+  saveCloudStore: async (value) => {
+    savedCloudStore = value;
+  },
+});
+
+assert.deepEqual(savedCredentials, { clientId: "client-id", clientSecret: "client-secret" });
+assert.equal(savedCloudStore, '{"token":{"access_token":"secret"}}');
+assert.equal(storage.getItem(LEGACY_CREDENTIAL_KEYS.clientId), null);
+assert.equal(storage.getItem(LEGACY_CLOUD_STORE_KEY), null);
+assert.equal(storage.getItem("homey_dashboard_favorites"), '["safe-public-preference"]');
+assert.equal(hasLegacySensitiveStorage(storage), false);
+
+const interruptedMigration = new MemoryStorage();
+interruptedMigration.setItem(LEGACY_CREDENTIAL_KEYS.clientId, "stale-client-id");
+interruptedMigration.setItem(LEGACY_CREDENTIAL_KEYS.clientSecret, "stale-client-secret");
+interruptedMigration.setItem(LEGACY_CLOUD_STORE_KEY, '{"token":{"access_token":"legacy"}}');
+let overwrittenCredentials = false;
+await migrateLegacyAuth(
+  interruptedMigration,
+  {
+    saveCredentials: async () => {
+      overwrittenCredentials = true;
+    },
+    loadCloudStore: async () => '{"token":{"access_token":"secure"}}',
+    saveCloudStore: async () => {
+      throw new Error("an existing secure token must not be overwritten");
+    },
+  },
+  false,
+);
+assert.equal(overwrittenCredentials, false);
+assert.equal(hasLegacySensitiveStorage(interruptedMigration), false);
+console.log("OK — legacy auth storage migration assertions passed");

--- a/apps/dashboard/shared/test/smoke.ts
+++ b/apps/dashboard/shared/test/smoke.ts
@@ -35,6 +35,7 @@ const triggered: string[] = [];
 const triggeredAdvanced: string[] = [];
 const updatedFlow: { id?: string; favorite?: boolean } = {};
 const updatedAdvanced: { id?: string; favorite?: boolean } = {};
+let logoutCalls = 0;
 
 const fakeApi: HomeyAPILike = {
   flow: {
@@ -82,7 +83,7 @@ class FakeCloud implements AthomCloudAPILike {
     return fakeUser;
   }
   async logout() {
-    /* noop */
+    logoutCalls += 1;
   }
 }
 
@@ -108,6 +109,8 @@ async function main() {
     credentials,
   });
   assert.equal(await session.isLoggedIn(), true);
+  await session.logout();
+  assert.equal(logoutCalls, 1, "sign-out delegates to the active Athom session");
 
   const client = await HomeyClient.connect(session);
   assert.equal(client.homey.id, "homey-abc");

--- a/apps/dashboard/src-tauri/Cargo.lock
+++ b/apps/dashboard/src-tauri/Cargo.lock
@@ -683,6 +683,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "dbus",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1536,6 +1546,7 @@ name = "homey-toolbox-dashboard"
 version = "0.0.4"
 dependencies = [
  "device_query",
+ "keyring",
  "serde",
  "serde_json",
  "tauri",
@@ -1960,6 +1971,21 @@ dependencies = [
  "bitflags 2.11.1",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
 ]
 
 [[package]]
@@ -2988,6 +3014,42 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -4732,6 +4794,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -4778,11 +4849,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4822,6 +4910,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4838,6 +4932,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4858,10 +4958,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4882,6 +4994,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4898,6 +5016,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4918,6 +5042,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4934,6 +5064,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -5269,6 +5405,26 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/apps/dashboard/src-tauri/Cargo.toml
+++ b/apps/dashboard/src-tauri/Cargo.toml
@@ -21,6 +21,7 @@ tauri-plugin-global-shortcut = "2"
 device_query = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
 
 [profile.release]
 panic = "abort"

--- a/apps/dashboard/src-tauri/src/lib.rs
+++ b/apps/dashboard/src-tauri/src/lib.rs
@@ -9,6 +9,8 @@ use std::time::{Duration, Instant};
 use std::sync::Mutex;
 
 use device_query::{DeviceQuery, DeviceState};
+use keyring::Entry;
+use serde::{Deserialize, Serialize};
 use tauri::menu::{Menu, MenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use tauri::{Emitter, Manager, PhysicalPosition};
@@ -25,6 +27,217 @@ static OAUTH_TEST_LOCK: Mutex<()> = Mutex::new(());
 
 const SNAP_THRESHOLD_PX: i32 = 24;
 const HOTZONE_TRIGGER_PX: i32 = 4;
+const KEYRING_SERVICE: &str = "no.tiwas.homeytoolbox.dashboard";
+const OAUTH_CREDENTIAL_ACCOUNT: &str = "oauth-credentials";
+const CLOUD_STORE_ACCOUNT: &str = "athom-cloud-store";
+const CLOUD_STORE_CHUNK_BYTES: usize = 2_000;
+const CLOUD_STORE_MAX_CHUNKS: usize = 16;
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct OAuthCredentials {
+    client_id: String,
+    client_secret: String,
+}
+
+fn keyring_entry(account: &str) -> Result<Entry, String> {
+    Entry::new(KEYRING_SERVICE, account)
+        .map_err(|error| format!("could not access OS credential store: {error}"))
+}
+
+fn load_secret(account: &str) -> Result<Option<String>, String> {
+    match keyring_entry(account)?.get_password() {
+        Ok(value) => Ok(Some(value)),
+        Err(keyring::Error::NoEntry) => Ok(None),
+        Err(error) => Err(format!("could not read OS credential store: {error}")),
+    }
+}
+
+fn clear_secret(account: &str) -> Result<(), String> {
+    match keyring_entry(account)?.delete_credential() {
+        Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+        Err(error) => Err(format!("could not clear OS credential store: {error}")),
+    }
+}
+
+#[derive(Clone, Copy)]
+struct CloudStoreManifest {
+    generation: usize,
+    chunk_count: usize,
+}
+
+fn cloud_store_chunk_account(generation: usize, index: usize) -> String {
+    format!("{CLOUD_STORE_ACCOUNT}-{generation}-{index}")
+}
+
+fn split_utf8_chunks(value: &str) -> Vec<&str> {
+    let mut chunks = Vec::new();
+    let mut start = 0;
+    let mut size = 0;
+    for (index, character) in value.char_indices() {
+        let character_size = character.len_utf8();
+        if size + character_size > CLOUD_STORE_CHUNK_BYTES {
+            chunks.push(&value[start..index]);
+            start = index;
+            size = 0;
+        }
+        size += character_size;
+    }
+    if start < value.len() {
+        chunks.push(&value[start..]);
+    }
+    chunks
+}
+
+fn cloud_store_manifest() -> Result<Option<CloudStoreManifest>, String> {
+    let Some(manifest) = load_secret(CLOUD_STORE_ACCOUNT)? else {
+        return Ok(None);
+    };
+    let (generation, chunk_count) = manifest
+        .split_once(':')
+        .and_then(|(generation, count)| Some((generation.parse().ok()?, count.parse().ok()?)))
+        .filter(|(generation, count): &(usize, usize)| {
+            *generation < 2 && (1..=CLOUD_STORE_MAX_CHUNKS).contains(count)
+        })
+        .ok_or_else(|| "stored cloud credential manifest is invalid".to_string())?;
+    Ok(Some(CloudStoreManifest {
+        generation,
+        chunk_count,
+    }))
+}
+
+fn load_cloud_store_secret() -> Result<Option<String>, String> {
+    let Some(manifest) = cloud_store_manifest()? else {
+        return Ok(None);
+    };
+    let mut store = String::new();
+    for index in 0..manifest.chunk_count {
+        let Some(chunk) = load_secret(&cloud_store_chunk_account(manifest.generation, index))?
+        else {
+            // A partial clear is equivalent to a logged-out session. Leave
+            // best-effort cleanup for now, but never let a stale manifest
+            // prevent the dashboard from reaching its login screen.
+            let _ = clear_cloud_store_secret();
+            return Ok(None);
+        };
+        store.push_str(&chunk);
+    }
+    Ok(Some(store))
+}
+
+fn serialize_secure_cloud_store(value: &str) -> Result<String, String> {
+    let store = serde_json::from_str::<serde_json::Value>(&value)
+        .map_err(|error| format!("cloud storage payload must be JSON: {error}"))?;
+    // AthomCloudAPI persists a `user` cache alongside the OAuth token. It is
+    // not needed to resume a session, so keep only the token and avoid putting
+    // an unbounded cache into the platform credential store.
+    let persisted = store
+        .get("token")
+        .cloned()
+        .map(|token| serde_json::json!({ "token": token }))
+        .unwrap_or_else(|| serde_json::json!({}));
+    serde_json::to_string(&persisted)
+        .map_err(|error| format!("could not serialize cloud credential: {error}"))
+}
+
+fn save_cloud_store_secret(value: String) -> Result<(), String> {
+    let serialized = serialize_secure_cloud_store(&value)?;
+    let chunks = split_utf8_chunks(&serialized);
+    if chunks.len() > CLOUD_STORE_MAX_CHUNKS {
+        return Err("cloud credential exceeds the secure storage limit".to_string());
+    }
+
+    let previous = cloud_store_manifest()?;
+    let generation = previous.map_or(0, |manifest| manifest.generation ^ 1);
+    for (index, chunk) in chunks.iter().enumerate() {
+        keyring_entry(&cloud_store_chunk_account(generation, index))?
+            .set_password(chunk)
+            .map_err(|error| format!("could not save OS credential: {error}"))?;
+    }
+    keyring_entry(CLOUD_STORE_ACCOUNT)?
+        .set_password(&format!("{generation}:{}", chunks.len()))
+        .map_err(|error| format!("could not save OS credential manifest: {error}"))?;
+    if let Some(previous) = previous {
+        for index in 0..previous.chunk_count {
+            // The new manifest is already durable; stale chunks are cleaned
+            // opportunistically and can never become active again.
+            let _ = clear_secret(&cloud_store_chunk_account(previous.generation, index));
+        }
+    }
+    Ok(())
+}
+
+fn clear_cloud_store_secret() -> Result<(), String> {
+    // Scan both bounded generations so a retry cleans up even when an earlier
+    // sign-out failed halfway through deleting credential-store entries.
+    for generation in 0..2 {
+        for index in 0..CLOUD_STORE_MAX_CHUNKS {
+            clear_secret(&cloud_store_chunk_account(generation, index))?;
+        }
+    }
+    clear_secret(CLOUD_STORE_ACCOUNT)
+}
+
+#[tauri::command]
+async fn load_oauth_credentials() -> Result<Option<OAuthCredentials>, String> {
+    tauri::async_runtime::spawn_blocking(|| {
+        load_secret(OAUTH_CREDENTIAL_ACCOUNT)?
+            .map(|value| {
+                serde_json::from_str(&value)
+                    .map_err(|error| format!("stored OAuth credentials are invalid: {error}"))
+            })
+            .transpose()
+    })
+    .await
+    .map_err(|error| format!("credential task panicked: {error}"))?
+}
+
+#[tauri::command]
+async fn save_oauth_credentials(client_id: String, client_secret: String) -> Result<(), String> {
+    if client_id.trim().is_empty() || client_secret.trim().is_empty() {
+        return Err("OAuth client ID and secret must not be empty".to_string());
+    }
+    tauri::async_runtime::spawn_blocking(move || {
+        let payload = serde_json::to_string(&OAuthCredentials {
+            client_id,
+            client_secret,
+        })
+        .map_err(|error| format!("could not serialize OAuth credentials: {error}"))?;
+        keyring_entry(OAUTH_CREDENTIAL_ACCOUNT)?
+            .set_password(&payload)
+            .map_err(|error| format!("could not save OS credential: {error}"))
+    })
+    .await
+    .map_err(|error| format!("credential task panicked: {error}"))?
+}
+
+#[tauri::command]
+async fn clear_oauth_credentials() -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(|| clear_secret(OAUTH_CREDENTIAL_ACCOUNT))
+        .await
+        .map_err(|error| format!("credential task panicked: {error}"))?
+}
+
+#[tauri::command]
+async fn load_cloud_store() -> Result<Option<String>, String> {
+    tauri::async_runtime::spawn_blocking(load_cloud_store_secret)
+        .await
+        .map_err(|error| format!("credential task panicked: {error}"))?
+}
+
+#[tauri::command]
+async fn save_cloud_store(value: String) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || save_cloud_store_secret(value))
+        .await
+        .map_err(|error| format!("credential task panicked: {error}"))?
+}
+
+#[tauri::command]
+async fn clear_cloud_store() -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(clear_cloud_store_secret)
+        .await
+        .map_err(|error| format!("credential task panicked: {error}"))?
+}
 
 const SUCCESS_HTML: &str = r#"<!doctype html><html><head><meta charset="utf-8"><title>Signed in</title>
 <style>body{font:14px system-ui;background:#14161c;color:#e8eaed;display:flex;justify-content:center;align-items:center;height:100vh;margin:0}</style>
@@ -37,7 +250,11 @@ const ERROR_HTML: &str = r#"<!doctype html><html><head><meta charset="utf-8"><ti
 /// Returns the `code` query parameter, or an error string suitable for surfacing
 /// to the frontend.
 #[tauri::command]
-async fn await_oauth_code(port: u16, state: String, timeout_ms: Option<u64>) -> Result<String, String> {
+async fn await_oauth_code(
+    port: u16,
+    state: String,
+    timeout_ms: Option<u64>,
+) -> Result<String, String> {
     OAUTH_CANCELLED.store(false, Ordering::SeqCst);
     let timeout = Duration::from_millis(timeout_ms.unwrap_or(120_000).clamp(1_000, 300_000));
     tauri::async_runtime::spawn_blocking(move || run_listener(port, &state, timeout))
@@ -106,13 +323,18 @@ fn run_listener(port: u16, expected_state: &str, timeout: Duration) -> Result<St
     }
 }
 
-fn parse_callback_request(request_line: &str, expected_state: &str) -> Result<String, &'static str> {
+fn parse_callback_request(
+    request_line: &str,
+    expected_state: &str,
+) -> Result<String, &'static str> {
     let mut parts = request_line.split_whitespace();
     if parts.next() != Some("GET") {
         return Err("callback must use GET");
     }
     let target = parts.next().ok_or("missing request target")?;
-    if !matches!(parts.next(), Some(version) if version.starts_with("HTTP/")) || parts.next().is_some() {
+    if !matches!(parts.next(), Some(version) if version.starts_with("HTTP/"))
+        || parts.next().is_some()
+    {
         return Err("malformed request line");
     }
     let (path, query) = target.split_once('?').ok_or("missing callback query")?;
@@ -131,7 +353,9 @@ fn parse_callback_request(request_line: &str, expected_state: &str) -> Result<St
             }
         }
     }
-    let code = code.filter(|value| !value.is_empty()).ok_or("missing code")?;
+    let code = code
+        .filter(|value| !value.is_empty())
+        .ok_or("missing code")?;
     if state.as_deref() != Some(expected_state) {
         return Err("invalid OAuth state");
     }
@@ -258,8 +482,7 @@ fn show_toast(app: tauri::AppHandle, text: String, duration_ms: u64) -> Result<(
     // entrance animation and removal, so they accumulate top-down and fade
     // independently — newer toasts push older ones DOWN in the stack
     // (newest appears at the top of the visible stack since we prepend).
-    let escaped =
-        serde_json::to_string(&text).map_err(|e| format!("serialize text: {e}"))?;
+    let escaped = serde_json::to_string(&text).map_err(|e| format!("serialize text: {e}"))?;
     let js = format!(
         r#"(function(){{
             var s=document.getElementById('stack'); if(!s) return;
@@ -497,6 +720,12 @@ pub fn run() {
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
+            load_oauth_credentials,
+            save_oauth_credentials,
+            clear_oauth_credentials,
+            load_cloud_store,
+            save_cloud_store,
+            clear_cloud_store,
             await_oauth_code,
             cancel_oauth_listener,
             load_favorites,
@@ -517,6 +746,35 @@ pub fn run() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cloud_store_discards_the_unbounded_user_cache() {
+        let input = serde_json::json!({
+            "token": { "access_token": "token", "refresh_token": "refresh" },
+            "user": { "large": "x".repeat(CLOUD_STORE_CHUNK_BYTES * 2) },
+        })
+        .to_string();
+        let stored = serialize_secure_cloud_store(&input).expect("valid cloud store");
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&stored)
+                .expect("valid stored JSON")
+                .get("token")
+                .and_then(|token| token.get("access_token"))
+                .and_then(serde_json::Value::as_str),
+            Some("token")
+        );
+        assert!(stored.len() < CLOUD_STORE_CHUNK_BYTES);
+    }
+
+    #[test]
+    fn cloud_store_chunks_on_utf8_boundaries() {
+        let input = "å".repeat(CLOUD_STORE_CHUNK_BYTES);
+        let chunks = split_utf8_chunks(&input);
+        assert!(chunks
+            .iter()
+            .all(|chunk| chunk.len() <= CLOUD_STORE_CHUNK_BYTES));
+        assert_eq!(chunks.concat(), input);
+    }
 
     #[test]
     fn accepts_callback_with_matching_state() {

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
@@ -23,7 +23,12 @@ import { Floorplan } from "./components/Floorplan";
 import { Settings } from "./components/Settings";
 import { getAthomCloudAPI } from "./lib/cloud";
 import { performLoopbackOAuth, REDIRECT_URL } from "./lib/oauth";
-import { clearCredentials, loadCredentials } from "./lib/storage";
+import {
+  clearCloudStore,
+  clearCredentials,
+  createSecureCloudStorage,
+  loadCredentials,
+} from "./lib/storage";
 import { loadSettings, saveSettings } from "./lib/settings-tauri";
 import { I18nProvider, useI18n } from "./i18n/context";
 
@@ -63,6 +68,7 @@ function AppInner({
   const [fatal, setFatal] = useState<string | null>(null);
   const [homeys, setHomeys] = useState<Array<{ id: string; name: string }>>([]);
   const [activeShortcut, setActiveShortcut] = useState<string>("");
+  const activeSession = useRef<AuthSession | null>(null);
 
   useEffect(() => {
     bootstrap().catch((e) => setFatal(e instanceof Error ? e.message : String(e)));
@@ -189,7 +195,12 @@ function AppInner({
     }
     const creds: AuthCredentials = { ...stored, redirectUrl: REDIRECT_URL };
     const AthomCloudAPI = await getAthomCloudAPI();
-    const session = new AuthSession({ AthomCloudAPI, credentials: creds });
+    const session = new AuthSession({
+      AthomCloudAPI,
+      credentials: creds,
+      store: createSecureCloudStorage(AthomCloudAPI),
+    });
+    activeSession.current = session;
     if (await session.isLoggedIn()) {
       const homeyList = await HomeyClient.listHomeys(session).catch(() => []);
       setHomeys(homeyList);
@@ -214,8 +225,13 @@ function AppInner({
       clientSecret: screen.creds.clientSecret,
     });
     const AthomCloudAPI = await getAthomCloudAPI();
-    const session = new AuthSession({ AthomCloudAPI, credentials: screen.creds });
+    const session = new AuthSession({
+      AthomCloudAPI,
+      credentials: screen.creds,
+      store: createSecureCloudStorage(AthomCloudAPI),
+    });
     await session.exchangeCode(code);
+    activeSession.current = session;
     const homeyList = await HomeyClient.listHomeys(session).catch(() => []);
     setHomeys(homeyList);
     const client = await HomeyClient.connect(session, settings.homeyId || undefined);
@@ -224,30 +240,32 @@ function AppInner({
 
   async function handleLogout() {
     setFatal(null);
-    [
-      "homey-api",
-      "homey_api_key",
-      "homey_access_token",
-      "homey_refresh_token",
-      "athom_access_token",
-      "athom_refresh_token",
-      "athom_token_expires_at",
-    ].forEach((k) => localStorage.removeItem(k));
-    Object.keys(localStorage)
-      .filter((k) => /^(homey|athom)[-_]/i.test(k))
-      .forEach((k) => localStorage.removeItem(k));
-    const stored = loadCredentials();
-    setScreen(
-      stored
-        ? { kind: "login", creds: { ...stored, redirectUrl: REDIRECT_URL } }
-        : { kind: "setup" },
-    );
+    const session = activeSession.current;
+    try {
+      // AuthSession.logout intentionally tolerates a remote failure. The local
+      // keychain cleanup below must still complete when the user is offline.
+      await session?.logout();
+      await clearCloudStore();
+      const stored = await loadCredentials();
+      activeSession.current = null;
+      setScreen(
+        stored
+          ? { kind: "login", creds: { ...stored, redirectUrl: REDIRECT_URL } }
+          : { kind: "setup" },
+      );
+    } catch (cause) {
+      setFatal(cause instanceof Error ? cause.message : String(cause));
+    }
   }
 
-  function handleResetCredentials() {
+  async function handleResetCredentials() {
     setFatal(null);
-    clearCredentials();
-    handleLogout();
+    try {
+      await clearCredentials();
+      await handleLogout();
+    } catch (cause) {
+      setFatal(cause instanceof Error ? cause.message : String(cause));
+    }
   }
 
   async function persistSettings(next: AppSettings) {

--- a/apps/dashboard/src/components/Setup.tsx
+++ b/apps/dashboard/src/components/Setup.tsx
@@ -8,11 +8,18 @@ export function Setup({ onSaved }: { onSaved: () => void }) {
   const [id, setId] = useState("");
   const [secret, setSecret] = useState("");
 
-  function submit(e: React.FormEvent) {
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit(e: React.FormEvent) {
     e.preventDefault();
     if (!id.trim() || !secret.trim()) return;
-    saveCredentials(id.trim(), secret.trim());
-    onSaved();
+    setError(null);
+    try {
+      await saveCredentials(id.trim(), secret.trim());
+      onSaved();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    }
   }
 
   return (
@@ -36,6 +43,7 @@ export function Setup({ onSaved }: { onSaved: () => void }) {
         <button className="primary" type="submit">
           {t.setup_save}
         </button>
+        {error && <p className="error">{error}</p>}
       </form>
     </div>
   );

--- a/apps/dashboard/src/lib/legacy-auth-storage.ts
+++ b/apps/dashboard/src/lib/legacy-auth-storage.ts
@@ -1,0 +1,70 @@
+export type LegacyStorage = Pick<Storage, "getItem" | "removeItem" | "key" | "length">;
+
+export type StoredCredentials = { clientId: string; clientSecret: string };
+
+export const LEGACY_CREDENTIAL_KEYS = {
+  clientId: "dashboard_client_id",
+  clientSecret: "dashboard_client_secret",
+} as const;
+
+export const LEGACY_CLOUD_STORE_KEY = "homey-api";
+
+const LEGACY_TOKEN_KEYS = [
+  "homey_api_key",
+  "homey_access_token",
+  "homey_refresh_token",
+  "athom_access_token",
+  "athom_refresh_token",
+  "athom_token_expires_at",
+];
+
+export function readLegacyCredentials(storage: Pick<Storage, "getItem">): StoredCredentials | null {
+  const clientId = storage.getItem(LEGACY_CREDENTIAL_KEYS.clientId);
+  const clientSecret = storage.getItem(LEGACY_CREDENTIAL_KEYS.clientSecret);
+  return clientId && clientSecret ? { clientId, clientSecret } : null;
+}
+
+export function legacySensitiveKeys(storage: LegacyStorage): string[] {
+  const keys = new Set([
+    LEGACY_CREDENTIAL_KEYS.clientId,
+    LEGACY_CREDENTIAL_KEYS.clientSecret,
+    LEGACY_CLOUD_STORE_KEY,
+    ...LEGACY_TOKEN_KEYS,
+  ]);
+  for (let index = 0; index < storage.length; index += 1) {
+    const key = storage.key(index);
+    if (key && /^(?:homey|athom)[-_].*(?:token|session|api[-_]?key|expires)/i.test(key)) {
+      keys.add(key);
+    }
+  }
+  return [...keys];
+}
+
+export function clearLegacySensitiveStorage(storage: LegacyStorage): void {
+  legacySensitiveKeys(storage).forEach((key) => storage.removeItem(key));
+}
+
+export function hasLegacySensitiveStorage(storage: LegacyStorage): boolean {
+  return legacySensitiveKeys(storage).some((key) => storage.getItem(key) !== null);
+}
+
+export async function migrateLegacyAuth(
+  storage: LegacyStorage,
+  secure: {
+    saveCredentials(credentials: StoredCredentials): Promise<void>;
+    loadCloudStore(): Promise<string | null>;
+    saveCloudStore(value: string): Promise<void>;
+  },
+  copyCredentials = true,
+): Promise<void> {
+  const credentials = readLegacyCredentials(storage);
+  if (copyCredentials && credentials) await secure.saveCredentials(credentials);
+
+  const legacyCloudStore = storage.getItem(LEGACY_CLOUD_STORE_KEY);
+  if (legacyCloudStore) {
+    const secureCloudStore = await secure.loadCloudStore();
+    if (!secureCloudStore || secureCloudStore === "{}") await secure.saveCloudStore(legacyCloudStore);
+  }
+
+  clearLegacySensitiveStorage(storage);
+}

--- a/apps/dashboard/src/lib/storage.ts
+++ b/apps/dashboard/src/lib/storage.ts
@@ -1,22 +1,62 @@
-const KEYS = {
-  clientId: "dashboard_client_id",
-  clientSecret: "dashboard_client_secret",
-  favorites: "homey_dashboard_favorites",
-} as const;
+import { invoke } from "@tauri-apps/api/core";
+import type { AthomCloudAPICtor, AthomStorageAdapter } from "@homey-toolbox/dashboard-shared";
+import {
+  clearLegacySensitiveStorage,
+  hasLegacySensitiveStorage,
+  migrateLegacyAuth,
+  type StoredCredentials,
+} from "./legacy-auth-storage";
 
-export function loadCredentials(): { clientId: string; clientSecret: string } | null {
-  const id = localStorage.getItem(KEYS.clientId);
-  const secret = localStorage.getItem(KEYS.clientSecret);
-  if (!id || !secret) return null;
-  return { clientId: id, clientSecret: secret };
+async function migrateLegacyStorage(copyCredentials: boolean): Promise<void> {
+  await migrateLegacyAuth(localStorage, {
+    saveCredentials: async ({ clientId, clientSecret }) => {
+      await invoke("save_oauth_credentials", { clientId, clientSecret });
+    },
+    loadCloudStore: () => invoke<string | null>("load_cloud_store"),
+    saveCloudStore: (value) => invoke("save_cloud_store", { value }),
+  }, copyCredentials);
 }
 
-export function saveCredentials(clientId: string, clientSecret: string): void {
-  localStorage.setItem(KEYS.clientId, clientId);
-  localStorage.setItem(KEYS.clientSecret, clientSecret);
+export async function loadCredentials(): Promise<StoredCredentials | null> {
+  const stored = await invoke<StoredCredentials | null>("load_oauth_credentials");
+  // Always clear any legacy WebView token after the first version using the
+  // keychain, including a previously interrupted migration.
+  if (!stored || hasLegacySensitiveStorage(localStorage)) await migrateLegacyStorage(!stored);
+  return stored ?? invoke<StoredCredentials | null>("load_oauth_credentials");
 }
 
-export function clearCredentials(): void {
-  localStorage.removeItem(KEYS.clientId);
-  localStorage.removeItem(KEYS.clientSecret);
+export async function saveCredentials(clientId: string, clientSecret: string): Promise<void> {
+  await invoke("save_oauth_credentials", { clientId, clientSecret });
+  clearLegacySensitiveStorage(localStorage);
+}
+
+export async function clearCredentials(): Promise<void> {
+  await invoke("clear_oauth_credentials");
+  clearLegacySensitiveStorage(localStorage);
+}
+
+export async function clearCloudStore(): Promise<void> {
+  await invoke("clear_cloud_store");
+  clearLegacySensitiveStorage(localStorage);
+}
+
+export function createSecureCloudStorage(AthomCloudAPI: AthomCloudAPICtor): AthomStorageAdapter {
+  const BaseStorageAdapter = AthomCloudAPI.StorageAdapter;
+  return new (class extends BaseStorageAdapter {
+    async get(): Promise<object> {
+      const raw = await invoke<string | null>("load_cloud_store");
+      if (!raw) return {};
+      try {
+        return JSON.parse(raw) as object;
+      } catch {
+        // A corrupt credential is not usable; do not expose it to the SDK.
+        await invoke("clear_cloud_store");
+        return {};
+      }
+    }
+
+    async set(value: object): Promise<void> {
+      await invoke("save_cloud_store", { value: JSON.stringify(value) });
+    }
+  })();
 }


### PR DESCRIPTION
Closes #14

- Store OAuth client credentials and Athom's token/cache adapter in the OS credential store (Windows Credential Manager, macOS Keychain, Linux Secret Service).
- Migrate and remove legacy WebView localStorage secrets without overwriting an existing secure record.
- Retain the active AuthSession and invoke logout before local cleanup; local cleanup still runs when remote logout fails.
- Add migration and logout coverage.

Verified with `npm run typecheck`, `npm run test:smoke`, `npm run test:floorplan`, `npm run test:legacy-auth-storage`, `npm run build`, `npm audit --omit=dev --json`, `cargo fmt --check`, and `cargo test`.