### PR TITLE
fix(logic): serialize formula evaluations

### DIFF
--- a/no.tiwas.booleantoolbox/LogicDevice.test.js
+++ b/no.tiwas.booleantoolbox/LogicDevice.test.js
@@ -7,6 +7,7 @@ jest.mock('homey', () => ({
 
 const LogicDeviceDevice = require('./drivers/logic-device/device');
 const LogicDeviceDriver = require('./drivers/logic-device/driver');
+const FormulaEvaluator = require('./lib/FormulaEvaluator');
 
 function createLogger() {
   return {
@@ -105,6 +106,47 @@ describe('LogicDeviceDevice linked inputs', () => {
     expect(device.homey.app.ensureHomeyApi).toHaveBeenCalledTimes(1);
     expect(device.deviceListeners.has('a-logic-group-id-alarm_generic')).toBe(true);
     expect(device.setInputForFormula).toHaveBeenCalledWith('formula_1', 'a', true);
+  });
+
+  test('drops a stale linked-input evaluation after a delayed capability write', async () => {
+    const device = Object.create(LogicDeviceDevice.prototype);
+    const capabilityValues = new Map([['alarm_generic', false], ['onoff', true]]);
+    device.logger = createLogger();
+    device.formulaEvaluator = new FormulaEvaluator();
+    device.deviceEnabled = true;
+    device.availableInputs = ['a'];
+    device.getName = jest.fn(() => 'Logic Device');
+    device.getData = jest.fn(() => ({ id: 'logic-device-id' }));
+    device.formulas = [{
+      id: 'formula_1', name: 'Latest wins', expression: 'A', enabled: true,
+      inputStates: { a: false }, lockedInputs: {}, result: false, timedOut: false,
+    }];
+    device.getCapabilityValue = jest.fn(capabilityId => capabilityValues.get(capabilityId));
+    device.hasCapability = jest.fn(() => true);
+    device.fireAllRelevantTriggers = jest.fn(async () => {});
+    let releaseFirstWrite;
+    const firstWriteStarted = new Promise(resolve => { releaseFirstWrite = resolve; });
+    let allowFirstWrite;
+    const firstWriteReleased = new Promise(resolve => { allowFirstWrite = resolve; });
+    let writes = 0;
+    device.safeSetCapabilityValue = jest.fn(async (capabilityId, value) => {
+      writes += 1;
+      if (writes === 1) {
+        releaseFirstWrite();
+        await firstWriteReleased;
+      }
+      capabilityValues.set(capabilityId, value);
+    });
+
+    const older = device.setInputForFormula('formula_1', 'a', true);
+    await firstWriteStarted;
+    const newer = device.setInputForFormula('formula_1', 'a', false);
+    allowFirstWrite();
+    await Promise.all([older, newer]);
+
+    expect(capabilityValues.get('alarm_generic')).toBe(false);
+    expect(device.formulas[0].result).toBe(false);
+    expect(device.fireAllRelevantTriggers).not.toHaveBeenCalled();
   });
 
   test('shares linked-input health refreshes across Logic Devices', async () => {

--- a/no.tiwas.booleantoolbox/LogicUnit.test.js
+++ b/no.tiwas.booleantoolbox/LogicUnit.test.js
@@ -130,6 +130,32 @@ describe("Logic Unit formula results", () => {
     await device.setInputForFormula("f1", "a", false);
     expect(device.capabilityValues.get("alarm_generic")).toBe(false);
   });
+
+  test("commits only the newest result when a capability write is delayed", async () => {
+    const formula = createFormula({ expression: "A", inputStates: { a: false, b: "undefined" }, result: false });
+    const device = createLogicUnit([formula]);
+    let releaseFirstWrite;
+    const firstWriteStarted = new Promise(resolve => { releaseFirstWrite = resolve; });
+    let allowFirstWrite;
+    const firstWriteReleased = new Promise(resolve => { allowFirstWrite = resolve; });
+    device.setCapabilityValue = jest.fn(async (capabilityId, value) => {
+      if (capabilityId === "alarm_generic" && device.setCapabilityValue.mock.calls.length === 1) {
+        releaseFirstWrite();
+        await firstWriteReleased;
+      }
+      device.capabilityValues.set(capabilityId, value);
+    });
+
+    const older = device.setInputForFormula("f1", "a", true);
+    await firstWriteStarted;
+    const newer = device.setInputForFormula("f1", "a", false);
+    allowFirstWrite();
+    await Promise.all([older, newer]);
+
+    expect(device.capabilityValues.get("alarm_generic")).toBe(false);
+    expect(formula.result).toBe(false);
+    expect(device.triggerCards.get("formula_changed_lu").trigger).not.toHaveBeenCalled();
+  });
 });
 
 describe("Logic Unit formula Flow cards", () => {

--- a/no.tiwas.booleantoolbox/drivers/logic-device/device.js
+++ b/no.tiwas.booleantoolbox/drivers/logic-device/device.js
@@ -41,6 +41,8 @@ let inputHealthCheckTimer = null;
  */
 module.exports = class LogicDeviceDevice extends Homey.Device {
   async onInit() {
+    this._evaluationQueue = Promise.resolve();
+    this._evaluationRevision = 0;
     const driverName = `Device: ${this.driver.id}`;
     this.logger = new Logger(this, driverName);
 
@@ -115,6 +117,8 @@ module.exports = class LogicDeviceDevice extends Homey.Device {
 
     // Register on/off capability listener to enable/disable device
     this.registerCapabilityListener("onoff", async (value) => {
+      const previousEvaluations = this._evaluationQueue ?? Promise.resolve();
+      this.invalidateEvaluations();
       this.deviceEnabled = value;
       this.logger.info(`🔌 Device ${value ? "enabled" : "disabled"}`, {});
 
@@ -137,6 +141,10 @@ module.exports = class LogicDeviceDevice extends Homey.Device {
           clearInterval(this.timeoutInterval);
           this.timeoutInterval = null;
         }
+        // A write already in progress cannot be cancelled. Wait for it before
+        // committing the disabled state so it cannot overwrite alarm_generic.
+        await previousEvaluations.catch((error) => this.logger.error("evaluation.queue_failed", error));
+        if (this.deviceEnabled !== false) return true;
         const previousAlarmState = this.getCapabilityValue("alarm_generic");
         await this.setCapabilityValue("alarm_generic", false).catch(() => {});
         
@@ -196,6 +204,8 @@ module.exports = class LogicDeviceDevice extends Homey.Device {
 
     // Check if formulas or input_links have changed
     if (this.lastKnownFormulas !== currentFormulas || this.lastKnownInputLinks !== currentInputLinks) {
+      this.invalidateEvaluations();
+      await (this._evaluationQueue ?? Promise.resolve()).catch((error) => this.logger.error("evaluation.queue_failed", error));
       this.logger.info("⚙️  Settings changed detected, reloading and validating...");
 
       // Update stored values
@@ -790,6 +800,7 @@ module.exports = class LogicDeviceDevice extends Homey.Device {
 
     formula.inputStates[inputId] = value;
     formula.timedOut = false;
+    this.invalidateEvaluations();
 
     if (
       formula.firstImpression &&
@@ -810,7 +821,30 @@ module.exports = class LogicDeviceDevice extends Homey.Device {
     return await this.evaluateFormula(formulaId);
   }
 
+  queueEvaluation(work) {
+    this._evaluationQueue ??= Promise.resolve();
+    const queued = this._evaluationQueue.then(work, work);
+    this._evaluationQueue = queued.catch((error) => {
+      this.logger?.error("evaluation.queue_failed", error);
+    });
+    return queued;
+  }
+
+  invalidateEvaluations() {
+    this._evaluationRevision = (this._evaluationRevision || 0) + 1;
+    return this._evaluationRevision;
+  }
+
+  isCurrentEvaluation(revision) {
+    return !this._isDeleting && this.deviceEnabled !== false && revision === (this._evaluationRevision || 0);
+  }
+
   async evaluateFormula(formulaId, resetLocks = false) {
+    const revision = this._evaluationRevision || 0;
+    return this.queueEvaluation(() => this._evaluateFormula(formulaId, resetLocks, revision));
+  }
+
+  async _evaluateFormula(formulaId, resetLocks = false, revision) {
     if (this._isDeleting) return null;
 
     // Check if device is enabled
@@ -888,13 +922,16 @@ module.exports = class LogicDeviceDevice extends Homey.Device {
         result,
       });
 
+      if (!this.isCurrentEvaluation(revision)) return null;
       const previousResult = formula.result;
-      formula.result = result;
-      formula.timedOut = false;
 
       // ✅ CRITICAL: Only set alarm_generic (formula output), NOT onoff!
       // onoff is user control (enable/disable), alarm_generic is formula result
       await this.safeSetCapabilityValue("alarm_generic", result);
+
+      if (!this.isCurrentEvaluation(revision)) return null;
+      formula.result = result;
+      formula.timedOut = false;
 
       // Trigger flows hvis resultatet endret seg
       if (previousResult !== null && previousResult !== result) {
@@ -1186,24 +1223,15 @@ module.exports = class LogicDeviceDevice extends Homey.Device {
 
     if (!anyEvaluated) {
       this.logger.warn("evaluation.no_formulas_ready");
-      
-      // Store previous state before updating
-      const previousAlarmState = this.getCapabilityValue("alarm_generic");
-      
-      // ✅ CRITICAL: Only set alarm_generic, NOT onoff!
-      // onoff is user control, alarm_generic is formula result
-      await this.safeSetCapabilityValue("alarm_generic", false);
-      
-      // Fire alarm triggers if state changed
-      if (previousAlarmState !== false) {
+      const revision = this._evaluationRevision || 0;
+      await this.queueEvaluation(async () => {
+        if (!this.isCurrentEvaluation(revision)) return;
+        const previousAlarmState = this.getCapabilityValue("alarm_generic");
+        await this.safeSetCapabilityValue("alarm_generic", false);
+        if (!this.isCurrentEvaluation(revision) || previousAlarmState === false) return;
         const currentOnState = this.getCapabilityValue("onoff");
-        await this.fireAllRelevantTriggers(
-          false,              // newAlarmState
-          currentOnState,     // newOnState
-          previousAlarmState, // previousAlarmState
-          null               // previousOnState (not changing)
-        );
-      }
+        await this.fireAllRelevantTriggers(false, currentOnState, previousAlarmState, null);
+      });
     }
   }
 
@@ -1743,6 +1771,8 @@ module.exports = class LogicDeviceDevice extends Homey.Device {
   }
 
   async onSettings({ newSettings, changedKeys }) {
+    this.invalidateEvaluations();
+    await (this._evaluationQueue ?? Promise.resolve()).catch((error) => this.logger.error("evaluation.queue_failed", error));
     this.logger.info("settings.changed", {
       keys: changedKeys.join(", "),
     });

--- a/no.tiwas.booleantoolbox/lib/BaseLogicUnit.js
+++ b/no.tiwas.booleantoolbox/lib/BaseLogicUnit.js
@@ -214,6 +214,8 @@ module.exports = class BaseLogicUnit extends Homey.Device {
    *   - BaseLogicUnit.startTimeoutChecks() - Start timeout interval
    */
   async onInit() {
+    this._evaluationQueue = Promise.resolve();
+    this._evaluationRevision = 0;
     const driverName = `Device: ${this.driver ? this.driver.id : "unknown-driver"}`;
     this.logger = new Logger(this, driverName);
 
@@ -1227,6 +1229,7 @@ module.exports = class BaseLogicUnit extends Homey.Device {
     formula.inputStates[inputId] =
       value === true || value === false ? value : "undefined";
     formula.timedOut = false;
+    this.invalidateEvaluations();
 
     // DEBUG: Log the specific change
     this.logger.info("🔍 DEBUG: Input value changed", {
@@ -1313,7 +1316,35 @@ module.exports = class BaseLogicUnit extends Homey.Device {
    *   - FormulaEvaluator.evaluate() - AST evaluation
    *   - Homey flow.getDeviceTriggerCard() - Trigger flow cards
    */
+  /**
+   * Evaluations can be requested by multiple Flow cards in the same event turn.
+   * Keep output commits ordered and discard work superseded by a newer input or
+   * settings revision before it can write capabilities or fire Flow triggers.
+   */
+  queueEvaluation(work) {
+    this._evaluationQueue ??= Promise.resolve();
+    const queued = this._evaluationQueue.then(work, work);
+    this._evaluationQueue = queued.catch((error) => {
+      this.logger?.error("evaluation.queue_failed", error);
+    });
+    return queued;
+  }
+
+  invalidateEvaluations() {
+    this._evaluationRevision = (this._evaluationRevision || 0) + 1;
+    return this._evaluationRevision;
+  }
+
+  isCurrentEvaluation(revision) {
+    return !this._isDeleting && revision === (this._evaluationRevision || 0);
+  }
+
   async evaluateFormula(formulaId, resetLocks = false) {
+    const revision = this._evaluationRevision || 0;
+    return this.queueEvaluation(() => this._evaluateFormula(formulaId, resetLocks, revision));
+  }
+
+  async _evaluateFormula(formulaId, resetLocks = false, revision) {
     if (this._isDeleting) return null;
     const formula = this.formulas.find((f) => f.id === formulaId);
     if (!formula || !formula.enabled) {
@@ -1395,11 +1426,17 @@ module.exports = class BaseLogicUnit extends Homey.Device {
         result: result,
       });
 
+      if (!this.isCurrentEvaluation(revision)) return null;
       const previous = formula.result;
       formula.result = result;
       formula.timedOut = false;
 
       await this.syncOverallAlarmState();
+
+      if (!this.isCurrentEvaluation(revision)) {
+        formula.result = previous;
+        return null;
+      }
 
       if (result !== previous && previous !== null) {
         this.logger.flow(
@@ -1635,6 +1672,8 @@ module.exports = class BaseLogicUnit extends Homey.Device {
   }
 
   async onSettings({ oldSettings, newSettings, changedKeys }) {
+    this.invalidateEvaluations();
+    await (this._evaluationQueue ?? Promise.resolve()).catch((error) => this.logger.error("evaluation.queue_failed", error));
     this.logger.info("settings.changed", {
       keys: changedKeys.join(", "),
     });
@@ -1798,6 +1837,8 @@ module.exports = class BaseLogicUnit extends Homey.Device {
 
     // Check if formulas have changed
     if (this.lastKnownFormulas !== currentFormulas) {
+      this.invalidateEvaluations();
+      await (this._evaluationQueue ?? Promise.resolve()).catch((error) => this.logger.error("evaluation.queue_failed", error));
       this.logger.info("⚙️  Settings changed detected, reloading and validating...");
 
       // Update stored value


### PR DESCRIPTION
Closes #29

- Serialize Logic Unit and Logic Device evaluation commits per virtual device.
- Invalidate in-flight work after inputs, settings changes, and Logic Device disable.
- Wait for an existing output write before committing the disabled state.
- Add deterministic delayed-write regression tests for conflicting inputs.

Verified with 
pm test -- --runInBand (196 tests) and homey app validate.