### PR TITLE
fix(logging): reduce Logic Unit input noise

### DIFF
--- a/no.tiwas.booleantoolbox/LogicUnit.test.js
+++ b/no.tiwas.booleantoolbox/LogicUnit.test.js
@@ -156,6 +156,15 @@ describe("Logic Unit formula results", () => {
     expect(formula.result).toBe(false);
     expect(device.triggerCards.get("formula_changed_lu").trigger).not.toHaveBeenCalled();
   });
+
+  test("does not log whole formula collections while handling normal input", async () => {
+    const device = createLogicUnit([createFormula()]);
+
+    await device.setInputForFormula("f1", "a", true);
+
+    expect(device.logger.info.mock.calls.some(([, data]) => data?.allFormulasState)).toBe(false);
+    expect(device.logger.debug.mock.calls.some(([, data]) => data?.allFormulasState)).toBe(false);
+  });
 });
 
 describe("Logic Unit formula Flow cards", () => {

--- a/no.tiwas.booleantoolbox/lib/BaseLogicUnit.js
+++ b/no.tiwas.booleantoolbox/lib/BaseLogicUnit.js
@@ -359,19 +359,11 @@ module.exports = class BaseLogicUnit extends Homey.Device {
   }
 
   async onFlowCondition(args, state, checkType) {
-    // DEBUG: Log the condition check details
-    this.logger.info("🔍 DEBUG: onFlowCondition called", {
+    this.logger.debug("flow.condition_checked", {
       checkType: checkType,
       formulaId: args.formula?.id,
       formulaName: args.formula?.name,
-      cardId: args.cardId,
-      allFormulasState: this.formulas.map(f => ({
-        id: f.id,
-        name: f.name,
-        result: f.result,
-        timedOut: f.timedOut,
-        inputStates: { ...f.inputStates }
-      }))
+      cardId: args.cardId
     });
 
     this.logger.flow(`onFlowCondition called for checkType: '${checkType}'`, {
@@ -1174,22 +1166,6 @@ module.exports = class BaseLogicUnit extends Homey.Device {
       return null;
     }
 
-    // DEBUG: Log current state of ALL formulas before any changes
-    this.logger.info("🔍 DEBUG: setInputForFormula BEFORE changes", {
-      targetFormula: formulaId,
-      targetInput: inputId,
-      targetValue: value,
-      allFormulasState: this.formulas.map(f => ({
-        id: f.id,
-        name: f.name,
-        inputStates: { ...f.inputStates },
-        lockedInputs: { ...f.lockedInputs },
-        sessionComplete: f.sessionComplete,
-        firstImpression: f.firstImpression,
-        result: f.result
-      }))
-    });
-
     // NEW: If firstImpression mode and a complete session exists, reset for new flow run
     if (
       formula.firstImpression === true &&
@@ -1206,12 +1182,7 @@ module.exports = class BaseLogicUnit extends Homey.Device {
       });
       formula.sessionComplete = false;
       
-      // DEBUG: Log state after reset
-      this.logger.info("🔍 DEBUG: Formula state AFTER reset", {
-        formula: formula.name,
-        inputStates: { ...formula.inputStates },
-        lockedInputs: { ...formula.lockedInputs }
-      });
+      this.logger.debug("inputs.reset_for_new_session", { formula: formula.name });
     }
 
     if (
@@ -1231,8 +1202,7 @@ module.exports = class BaseLogicUnit extends Homey.Device {
     formula.timedOut = false;
     this.invalidateEvaluations();
 
-    // DEBUG: Log the specific change
-    this.logger.info("🔍 DEBUG: Input value changed", {
+    this.logger.debug("inputs.value_changed", {
       formula: formula.name,
       input: inputId,
       oldValue: oldValue,
@@ -1270,20 +1240,6 @@ module.exports = class BaseLogicUnit extends Homey.Device {
         });
       }
     }
-
-    // DEBUG: Log current state of ALL formulas after changes
-    this.logger.info("🔍 DEBUG: setInputForFormula AFTER changes", {
-      targetFormula: formulaId,
-      allFormulasState: this.formulas.map(f => ({
-        id: f.id,
-        name: f.name,
-        inputStates: { ...f.inputStates },
-        lockedInputs: { ...f.lockedInputs },
-        sessionComplete: f.sessionComplete,
-        firstImpression: f.firstImpression,
-        result: f.result
-      }))
-    });
 
     return await this.evaluateFormula(formulaId, false);
   }

--- a/no.tiwas.booleantoolbox/lib/Logger.js
+++ b/no.tiwas.booleantoolbox/lib/Logger.js
@@ -66,7 +66,7 @@ class Logger {
    * Gets the default configuration, loading from loggerConfig.js if available.
    *
    * Uses a static cache to avoid re-reading the config file on every Logger instantiation.
-   * Falls back to DEBUG level if config file is not found.
+   * Falls back to INFO level if config file is not found.
    *
    * @private
    * @static
@@ -90,7 +90,7 @@ class Logger {
       return Logger._globalConfig;
     } catch (e) {
       const defaultConfig = {
-        defaultLevel: "DEBUG", // ENDRET: Fallback til DEBUG
+        defaultLevel: "INFO",
         categoryLevels: {},
         options: {},
       };
@@ -157,7 +157,7 @@ class Logger {
       level = globalConfig.categoryLevels[category];
     }
     if (!level) {
-      level = globalConfig.defaultLevel || "DEBUG"; // ENDRET: Fallback til DEBUG
+      level = globalConfig.defaultLevel || "INFO";
     }
 
     this.options = {
@@ -171,7 +171,7 @@ class Logger {
     if (Logger.LEVELS[this.options.level] !== undefined) {
       this.minLevel = Logger.LEVELS[this.options.level];
     } else {
-      this.minLevel = Logger.LEVELS.DEBUG; // Fallback
+      this.minLevel = Logger.LEVELS.INFO;
     }
     // --- SLUTT FIKS ---
 

--- a/no.tiwas.booleantoolbox/lib/loggerConfig.js
+++ b/no.tiwas.booleantoolbox/lib/loggerConfig.js
@@ -14,7 +14,7 @@
 module.exports = {
   // Default log level for any logger not specified below.
   // Options: 'DEBUG', 'INFO', 'WARN', 'ERROR', 'NONE'
-  defaultLevel: 'DEBUG',
+  defaultLevel: 'INFO',
 
   // Override log levels for specific categories (class names).
   // This helps in reducing noise or enabling detailed logs for specific parts of the app.


### PR DESCRIPTION
Closes #30

- Remove full formula-state snapshots from normal input and Flow-condition handling.
- Keep diagnostics at DEBUG and reserve INFO for lifecycle/state transitions.
- Default production logging and fallback logging to INFO.
- Add a regression assertion that normal input handling does not serialize formula collections.

Verified with 
pm test -- --runInBand (197 tests) and homey app validate.