### PR TITLE
test(dashboard): add shared package test command

### DIFF
--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -101,6 +101,28 @@ First launch flow:
 2. **Sign in** → opens system browser → consent → returns to app
 3. Dashboard loads your flows
 
+## Local release checks
+
+CI is intentionally disabled for this repository, so run the checks locally before creating a release:
+
+```sh
+# Shared OAuth/client, API-error, floorplan-sanitizer and editor-security tests
+cd shared
+npm install
+npm test
+npm run typecheck
+
+# Dashboard build
+cd ..
+npm run build
+
+# Native-shell tests
+cd src-tauri
+cargo test
+```
+
+`npm test` is the complete shared-package suite; individual `test:*` scripts remain available when narrowing down a failure.
+
 ## Building installers
 
 From this directory:

--- a/apps/dashboard/shared/package.json
+++ b/apps/dashboard/shared/package.json
@@ -8,6 +8,7 @@
   "types": "./src/index.ts",
   "scripts": {
     "typecheck": "tsc --noEmit",
+    "test": "npm run test:smoke && npm run test:floorplan && npm run test:legacy-auth-storage && npm run test:boolean-editor-xss",
     "test:smoke": "tsx test/smoke.ts",
     "test:floorplan": "tsx test/floorplan-sanitizer.ts",
     "test:legacy-auth-storage": "tsx test/legacy-auth-storage.ts",


### PR DESCRIPTION
Closes #19

- Add 
pm test for the complete dashboard shared-package suite.
- Include OAuth/client smoke coverage, API-error paths, floorplan sanitizer, legacy auth storage, and Boolean Editor XSS checks.
- Document the full local dashboard release-test commands while CI is disabled.

Verified with 
pm test, 
pm run typecheck, 
pm run build, and cargo test.