### PR TITLE
feat: add GitHub diagnostic reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Generated files
 app.json
+!no.tiwas.booleantoolbox/.homeycompose/app.json
 .homeybuild/
 no.tiwas.*/app.json
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to Smart (Components) Toolkit for Homey will be documented i
 
 ---
 
+## [1.10.28] - September 2026 (Test channel)
+
+### Added
+- App Settings can now generate a privacy-conscious diagnostic report and open the existing GitHub bug form with the report prefilled.
+- Reports include app version and uptime, recent persisted warnings/errors with stack traces, anonymous app-device counts, Circadian Light Group member/scheduler load, and available app/Homey CPU, memory, and storage data.
+
+### Changed
+- The startup banner now uses the manifest version, keeping runtime diagnostics aligned with the installed app version.
+
 ## [1.10.27] - September 2026 (Test channel)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to Smart (Components) Toolkit for Homey will be documented i
 ## [1.10.28] - September 2026 (Test channel)
 
 ### Added
-- App Settings can now generate a privacy-conscious diagnostic report and open the existing GitHub bug form with the report prefilled.
+- App Settings can now generate a privacy-conscious diagnostic report and open a new GitHub issue with the report prefilled.
 - Reports include app version and uptime, recent persisted warnings/errors with stack traces, anonymous app-device counts, Circadian Light Group member/scheduler load, and available app/Homey CPU, memory, and storage data.
 
 ### Changed

--- a/HOMEY_COMMUNITY_LISTING.md
+++ b/HOMEY_COMMUNITY_LISTING.md
@@ -21,7 +21,7 @@ Replace complex flow networks with powerful logic devices controlled by dynamic 
 
 - **Diagnostic report from App Settings:** generate a readable report containing the installed version, current-session uptime, recent warnings/errors and stack traces.
 - **Resource and setup load:** includes available app/Homey CPU, memory and storage data, anonymous app-device counts, and Circadian Light Group member, watcher and scheduler details.
-- **Prefilled GitHub issue:** review the report, then open the existing bug form with the version and report already filled in. Nothing is uploaded automatically.
+- **Prefilled GitHub issue:** review the report, then open a new issue with the version and report already filled in. Nothing is uploaded automatically.
 - **Privacy-conscious:** device names and IDs are omitted from structured data, and common identifiers and secrets are redacted from captured log lines. Always review before submitting.
 
 ### v1.10.27 (test channel)

--- a/HOMEY_COMMUNITY_LISTING.md
+++ b/HOMEY_COMMUNITY_LISTING.md
@@ -1,11 +1,11 @@
 URL: https://community.homey.app/t/app-smart-components-toolkit-was-boolean-toolbox-create-advanced-logic-with-simple-formulas-v1-10-16-store-v1-10-27-test-logic-device-reliability/143906
 
-Title: [APP] Smart (Components) Toolkit (was: Boolean Toolbox) - Create advanced logic with simple formulas [v1.10.16 store / v1.10.27 test - Logic Device reliability]
+Title: [APP] Smart (Components) Toolkit (was: Boolean Toolbox) - Create advanced logic with simple formulas [v1.10.16 store / v1.10.28 test - GitHub diagnostics]
 
 Content:
 ![xlarge|690x483](upload://iSxhJPUltgcgPQ7gy4z5iisCv5F.jpeg)
 
-# Smart (Components) Toolkit — store v1.10.16 / test v1.10.27
+# Smart (Components) Toolkit — store v1.10.16 / test v1.10.28
 
 > **📚 Full Documentation:** https://tiwas.github.io/SmartComponentsToolkit/
 
@@ -17,10 +17,20 @@ Replace complex flow networks with powerful logic devices controlled by dynamic 
 
 ## What's new
 
+### v1.10.28 (test channel)
+
+- **Diagnostic report from App Settings:** generate a readable report containing the installed version, current-session uptime, recent warnings/errors and stack traces.
+- **Resource and setup load:** includes available app/Homey CPU, memory and storage data, anonymous app-device counts, and Circadian Light Group member, watcher and scheduler details.
+- **Prefilled GitHub issue:** review the report, then open the existing bug form with the version and report already filled in. Nothing is uploaded automatically.
+- **Privacy-conscious:** device names and IDs are omitted from structured data, and common identifiers and secrets are redacted from captured log lines. Always review before submitting.
+
 ### v1.10.27 (test channel)
+
+This test release is a general reliability improvement based on a thorough code review.
 
 - **Reliable Logic Device updates:** formula evaluations are serialized and stale results are discarded, so bursts of linked-device updates cannot leave a Logic Device on an old result.
 - **Quieter diagnostics:** normal Logic Unit updates no longer flood the app log.
+- **Lean release package:** development-only material is excluded and manifest assets are verified before release.
 
 ### v1.10.25 (test channel)
 

--- a/PROJECT_DOCUMENTATION.md
+++ b/PROJECT_DOCUMENTATION.md
@@ -35,7 +35,7 @@
 ### 5. Diagnostics and GitHub issue reporting
 *   **Settings UI:** `no.tiwas.booleantoolbox/settings/index.html` generates an on-demand report, shows it for review, supports copying, and opens a new repository issue prefilled.
 *   **API:** the private `POST /diagnostics` app endpoint in `api.js` delegates report creation to `app.js`; no GitHub credentials are stored in the app.
-*   **Report data:** `lib/DiagnosticsReport.js` formats/redacts version, session uptime, persisted warning/error stacks, anonymous driver and Circadian Light Group load, and available app/Homey CPU, memory, and storage metrics.
+*   **Report data:** `lib/DiagnosticsReport.js` formats/redacts version, session uptime, label-free warning/error events with stack frames, anonymous driver and Circadian Light Group load, and available app/Homey CPU, memory, and storage metrics.
 
 ## Project Structure
 *   `no.tiwas.booleantoolbox/`: Main Homey app source.

--- a/PROJECT_DOCUMENTATION.md
+++ b/PROJECT_DOCUMENTATION.md
@@ -32,11 +32,17 @@
 *   **Flow Triggers:** `composite_value_changed` fires for subsequent numeric, boolean, or text output changes. `composite_value_changed_larger_than` filters numeric changes using a per-Flow fixed or percentage threshold.
 *   **Tests:** `CompositeAggregator.test.js` verifies calculation semantics and `CompositeDevice.test.js` verifies pairing, realtime updates, change triggers, threshold filters, partial failures, and cleanup.
 
+### 5. Diagnostics and GitHub issue reporting
+*   **Settings UI:** `no.tiwas.booleantoolbox/settings/index.html` generates an on-demand report, shows it for review, supports copying, and opens the repository bug form prefilled.
+*   **API:** the private `POST /diagnostics` app endpoint in `api.js` delegates report creation to `app.js`; no GitHub credentials are stored in the app.
+*   **Report data:** `lib/DiagnosticsReport.js` formats/redacts version, session uptime, persisted warning/error stacks, anonymous driver and Circadian Light Group load, and available app/Homey CPU, memory, and storage metrics.
+
 ## Project Structure
 *   `no.tiwas.booleantoolbox/`: Main Homey app source.
-    *   `app.js`: Application entry point.
+    *   `app.js`: Application entry point and diagnostics collector.
+    *   `api.js`: Private settings endpoint for generating diagnostic reports.
     *   `drivers/`: Device drivers (`composite-device`, `logic-device`, `logic-unit`, state and Circadian Light Group drivers).
-    *   `lib/`: Core logic libraries (`CompositeAggregator.js`, `FormulaEvaluator.js`, `Logger.js`).
+    *   `lib/`: Core logic libraries (`CompositeAggregator.js`, `DiagnosticsReport.js`, `FormulaEvaluator.js`, `Logger.js`).
     *   `locales/`: Translation files.
 *   `docs/`: Documentation for the GitHub Pages site.
 *   Jest test files live beside the app source, including `CompositeAggregator.test.js`, `CompositeDevice.test.js`, `FormulaEvaluator.test.js`, and `LogicUnit.test.js`.

--- a/PROJECT_DOCUMENTATION.md
+++ b/PROJECT_DOCUMENTATION.md
@@ -33,7 +33,7 @@
 *   **Tests:** `CompositeAggregator.test.js` verifies calculation semantics and `CompositeDevice.test.js` verifies pairing, realtime updates, change triggers, threshold filters, partial failures, and cleanup.
 
 ### 5. Diagnostics and GitHub issue reporting
-*   **Settings UI:** `no.tiwas.booleantoolbox/settings/index.html` generates an on-demand report, shows it for review, supports copying, and opens the repository bug form prefilled.
+*   **Settings UI:** `no.tiwas.booleantoolbox/settings/index.html` generates an on-demand report, shows it for review, supports copying, and opens a new repository issue prefilled.
 *   **API:** the private `POST /diagnostics` app endpoint in `api.js` delegates report creation to `app.js`; no GitHub credentials are stored in the app.
 *   **Report data:** `lib/DiagnosticsReport.js` formats/redacts version, session uptime, persisted warning/error stacks, anonymous driver and Circadian Light Group load, and available app/Homey CPU, memory, and storage metrics.
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Virtual light device that adjusts brightness and color temperature for a group o
 
 ## 🩺 Diagnostics and support
 
-App Settings can generate a local diagnostic report and open the GitHub bug form with the report prefilled. The report includes app uptime, recent warnings/errors and stack traces, anonymous device counts, Circadian Light Group scheduler/member load, and available CPU, memory, and storage data. Common identifiers and secrets are redacted, nothing is uploaded automatically, and the report remains editable before submission.
+App Settings can generate a local diagnostic report and open a new GitHub issue with the report prefilled. The report includes app uptime, recent warnings/errors and stack traces, anonymous device counts, Circadian Light Group scheduler/member load, and available CPU, memory, and storage data. Common identifiers and secrets are redacted, nothing is uploaded automatically, and the report remains editable before submission.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 Advanced logic and state management for your Homey automations. Create smart devices that react to multiple inputs with customizable formulas, and manage device states with powerful capture/restore functionality.
 
 [![Stable](https://img.shields.io/badge/stable-1.10.9-blue.svg)](https://homey.app/en-no/app/no.tiwas.booleantoolbox/)
-[![Test](https://img.shields.io/badge/test-1.10.27-orange.svg)](https://homey.app/a/no.tiwas.booleantoolbox/test/)
+[![Test](https://img.shields.io/badge/test-1.10.28-orange.svg)](https://homey.app/a/no.tiwas.booleantoolbox/test/)
 [![Homey](https://img.shields.io/badge/Homey-5.0+-green.svg)](https://homey.app)
 
-> **v1.10.27 test** — prevents stale Logic Device formula results during bursts of updates and reduces routine Logic Unit logging.
+> **v1.10.28 test** — adds privacy-conscious diagnostic reports that can be reviewed and submitted through a prefilled GitHub issue.
 
 ---
 
@@ -138,7 +138,7 @@ THEN: Pop state (restore previous)
 
 ---
 
-### Circadian Light Group *(stable v1.10.16 / test v1.10.27)*
+### Circadian Light Group *(stable v1.10.16 / test v1.10.28)*
 
 Virtual light device that adjusts brightness and color temperature for a group of real lights based on time, sun position or ambient lux.
 
@@ -159,6 +159,12 @@ Virtual light device that adjusts brightness and color temperature for a group o
 **Install via test channel:** [homey.app/a/no.tiwas.booleantoolbox/test/](https://homey.app/a/no.tiwas.booleantoolbox/test/)
 
 [📚 Read Circadian Light Group guide →](https://tiwas.github.io/SmartComponentsToolkit/docs/circadian-light-group.html)
+
+---
+
+## 🩺 Diagnostics and support
+
+App Settings can generate a local diagnostic report and open the GitHub bug form with the report prefilled. The report includes app uptime, recent warnings/errors and stack traces, anonymous device counts, Circadian Light Group scheduler/member load, and available CPU, memory, and storage data. Common identifiers and secrets are redacted, nothing is uploaded automatically, and the report remains editable before submission.
 
 ---
 

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -10,16 +10,17 @@
 ### Implemented
 - Added a private App Settings diagnostics endpoint and UI for generating, previewing, copying, and opening a prefilled GitHub issue without embedding GitHub credentials.
 - Added bounded persistence of recent warnings/errors with stack traces and redaction of common device IDs, email/IP values, credentials, and long token-like values.
+- Reduced persisted logger events to label-free messages and stack frames so user-defined device, room, waiter, and formula labels are not copied into public issue drafts.
 - Added anonymous per-driver device counts, configuration-alarm counts, Circadian Light Group member/watcher/update-interval details, process and Homey-reported memory, system load averages, app CPU metric, and Homey storage totals when exposed by the platform.
 - Aligned the runtime startup banner and npm package metadata with Homey app version 1.10.28.
 - Updated README, Store README, changelog, project documentation, and Homey Community post source.
 
 ### Verification
 - JavaScript syntax and changed locale/manifest JSON parsing passed.
-- `npm test -- --runInBand`: 18 suites and 206 tests passed.
+- `npm test -- --runInBand`: 19 suites and 209 tests passed.
 - `npm run test:package`: publish-level validation passed; bundle contains 766 files (7.51 MB) and all 17 manifest assets were verified.
 - `homey app run --remote`: v1.10.28 initialized successfully with the correct version banner and remained running without an app restart during the smoke-test window.
-- GitHub review, Homey upload/install, and final release result are recorded below when completed.
+- GitHub review found six issues across two passes; all findings were addressed with regression coverage before merge. Homey upload/install and the final release result are recorded below when completed.
 
 ## 2026-09-05 — Test release v1.10.27
 

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -1,5 +1,26 @@
 # Worklog
 
+## 2026-09-06 — GitHub diagnostic reports and test release v1.10.28
+
+### Requested
+- Add a way for users to submit a diagnostic report directly to GitHub Issues.
+- Include available device/app CPU, memory, storage and Circadian Light Group load information.
+- Prepare a reviewed PR, merge it when green, upload a Homey test build, install it on the configured Homey, and update the Community post source.
+
+### Implemented
+- Added a private App Settings diagnostics endpoint and UI for generating, previewing, copying, and opening a prefilled GitHub bug report without embedding GitHub credentials.
+- Added bounded persistence of recent warnings/errors with stack traces and redaction of common device IDs, email/IP values, credentials, and long token-like values.
+- Added anonymous per-driver device counts, configuration-alarm counts, Circadian Light Group member/watcher/update-interval details, process and Homey-reported memory, system load averages, app CPU metric, and Homey storage totals when exposed by the platform.
+- Aligned the runtime startup banner and npm package metadata with Homey app version 1.10.28.
+- Updated README, Store README, changelog, project documentation, and Homey Community post source.
+
+### Verification
+- JavaScript syntax and changed locale/manifest JSON parsing passed.
+- `npm test -- --runInBand`: 18 suites and 206 tests passed.
+- `npm run test:package`: publish-level validation passed; bundle contains 766 files (7.51 MB) and all 17 manifest assets were verified.
+- `homey app run --remote`: v1.10.28 initialized successfully with the correct version banner and remained running without an app restart during the smoke-test window.
+- GitHub review, Homey upload/install, and final release result are recorded below when completed.
+
 ## 2026-09-05 — Test release v1.10.27
 
 ### Requested
@@ -161,3 +182,27 @@
 - Uploaded Homey Build 52 and published v1.10.23 to the test channel.
 - Installed the app successfully on `Lars's New Homey` with `homey app install`.
 - Updated and verified the existing Homey Community topic with the v1.10.23 title and release notes.
+
+## 2026-09-06 — 30-second restart/reset diagnosis
+
+### Requested
+- Investigate a user report that the app resets itself every 30 seconds by running the app remotely over time.
+- Determine what diagnostics the user can submit and whether the app should expose stack traces or additional logs.
+
+### Findings
+- Ran `homey app run --remote` for approximately 5 minutes and 16 seconds. The app completed one initialization and remained running through more than ten reported 30-second windows without a restart, repeated `onInit`, unhandled rejection, fatal error, or memory/heap error.
+- The only runtime errors were handled Homey API failures for unavailable Z-Wave devices (`TRANSMIT_COMPLETE_NO_ACK` and `This device is currently unavailable`) during Circadian Light Group updates. The retry path completed without terminating the app.
+- Found a stronger explanation if "reset" means that light values are restored: Circadian Light Group reapplies its target on a configurable scheduler whose hard minimum is exactly 30 seconds. The local configuration uses 120 seconds, and the remote log showed normal `apply[timer]` cycles at that interval without app reinitialization.
+- Reviewed five earlier long-running remote logs. Each contained exactly one startup banner and one completed initialization, with no app uninitialization or fatal/unhandled/heap markers. The longest session logged activity continuously for almost three days.
+- Confirmed that the app already logs stack traces when a real `Error` object reaches `Logger.error`, but it has no user-downloadable persistent ring buffer or diagnostic snapshot. The startup banner currently reads the stale package version (1.10.25) while the generated/Compose manifest is 1.10.27, which can confuse incident reports.
+- Homey's built-in app management offers **Send diagnostics to developer**; a separate Homey system diagnostics report can also be created for Homey Support.
+
+### Recommendation
+- First ask the reporter whether the app itself shows a crash/restart or whether controlled device values revert, and whether a Circadian Light Group is configured with a 30-second update interval.
+- Ask the user to enable the app's Debug Mode, reproduce the issue, immediately send app diagnostics, and include the exact local time, app version, affected device/group, and what visibly resets.
+- Add a bounded in-memory diagnostic ring buffer and a redacted downloadable diagnostic snapshot with startup/session ID, manifest version, uptime, last scheduler operations, last errors with stacks, and lightweight memory counters. Do not rely on global `uncaughtException` handlers to keep a damaged process alive.
+
+### Verification
+- Current remote observation: one startup, normal 120-second scheduler cycles, no restart or fatal process signal.
+- Historical log scan: five sessions, one initialization per session, zero fatal/unhandled/heap markers.
+- No production code was changed during this diagnostic session.

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -8,7 +8,7 @@
 - Prepare a reviewed PR, merge it when green, upload a Homey test build, install it on the configured Homey, and update the Community post source.
 
 ### Implemented
-- Added a private App Settings diagnostics endpoint and UI for generating, previewing, copying, and opening a prefilled GitHub bug report without embedding GitHub credentials.
+- Added a private App Settings diagnostics endpoint and UI for generating, previewing, copying, and opening a prefilled GitHub issue without embedding GitHub credentials.
 - Added bounded persistence of recent warnings/errors with stack traces and redaction of common device IDs, email/IP values, credentials, and long token-like values.
 - Added anonymous per-driver device counts, configuration-alarm counts, Circadian Light Group member/watcher/update-interval details, process and Homey-reported memory, system load averages, app CPU metric, and Homey storage totals when exposed by the platform.
 - Aligned the runtime startup banner and npm package metadata with Homey app version 1.10.28.

--- a/no.tiwas.booleantoolbox/.homeycompose/app.json
+++ b/no.tiwas.booleantoolbox/.homeycompose/app.json
@@ -1,0 +1,83 @@
+{
+  "id": "no.tiwas.booleantoolbox",
+  "support": "https://community.homey.app/t/app-boolean-toolbox-create-advanced-logic-with-simple-formulas/143906",
+  "version": "1.10.28",
+  "compatibility": ">=5.0.0",
+  "sdk": 3,
+  "permissions": [
+    "homey:manager:api",
+    "homey:manager:geolocation"
+  ],
+  "name": {
+    "en": "Smart (Components) Toolkit",
+    "no": "Smart (Components) Toolkit",
+    "de": "Smart (Components) Toolkit",
+    "nl": "Smart (Components) Toolkit",
+    "fr": "Smart (Components) Toolkit",
+    "da": "Smart (Components) Toolkit",
+    "fi": "Smart (Components) Toolkit",
+    "sv": "Smart (Components) Toolkit",
+    "pl": "Smart (Components) Toolkit",
+    "it": "Smart (Components) Toolkit",
+    "es": "Smart (Components) Toolkit"
+  },
+  "description": {
+    "en": "Create advanced, state-aware logic units with multiple formulas.",
+    "no": "Lag avanserte, tilstandsbevisste logiske enheter med flere formler.",
+    "de": "Erstellen Sie erweiterte, zustandsbewusste Logikeinheiten mit mehreren Formeln.",
+    "nl": "Maak geavanceerde, toestandsbewuste logische eenheden met meerdere formules.",
+    "fr": "Créez des unités logiques avancées et conscientes de l'état avec plusieurs formules.",
+    "da": "Opret avancerede, tilstandsbevidste logiske enheder med flere formler.",
+    "fi": "Luo edistyneitä, tilatietoisia logiikkayksiköitä useilla kaavoilla.",
+    "sv": "Skapa avancerade, tillståndsmedvetna logikenheter med flera formler.",
+    "pl": "Twórz zaawansowane, świadome stanu jednostki logiczne z wieloma formułami.",
+    "it": "Crea unità logiche avanzate e consapevoli dello stato con formule multiple.",
+    "es": "Crea unidades lógicas avanzadas y conscientes del estado con múltiples fórmulas."
+  },
+  "category": "tools",
+  "brandColor": "#FF0000",
+  "author": {
+    "name": "Lars Kvanum"
+  },
+  "contributing": {
+    "donate": {
+      "paypal": {
+        "username": "tiwasno"
+      }
+    }
+  },
+  "bugs": {
+    "url": "https://github.com/Tiwas/SmartComponentsToolkit/issues"
+  },
+  "source": "https://github.com/Tiwas/SmartComponentsToolkit",
+  "homepage": "https://tiwas.github.io/SmartComponentsToolkit/",
+  "images": {
+    "xlarge": "/assets/images/xlarge.jpg",
+    "large": "/assets/images/large.jpg",
+    "small": "/assets/images/small.jpg"
+  },
+  "api": {
+    "getDiagnostics": {
+      "method": "POST",
+      "path": "/diagnostics"
+    }
+  },
+  "flow": {
+    "conditions": [
+      {
+        "id": "has_error"
+      },
+      {
+        "id": "math_compare"
+      }
+    ],
+    "actions": [
+      {
+        "id": "calculate_gradient"
+      },
+      {
+        "id": "evaluate_expression"
+      }
+    ]
+  }
+}

--- a/no.tiwas.booleantoolbox/AppDiagnostics.test.js
+++ b/no.tiwas.booleantoolbox/AppDiagnostics.test.js
@@ -118,4 +118,32 @@ describe("BooleanToolboxApp diagnostics", () => {
         expect(settings.set).toHaveBeenCalledWith("diagnostic_events", app.diagnosticEvents);
         jest.useRealTimers();
     });
+
+    test("treats a null Circadian configuration as a collection note", () => {
+        const app = new BooleanToolboxApp();
+        app.homey = {
+            drivers: {
+                getDrivers: jest.fn(() => ({
+                    "circadian-light-group": {
+                        id: "circadian-light-group",
+                        getDevices: jest.fn(() => [{
+                            hasCapability: jest.fn(() => false),
+                            getCapabilityValue: jest.fn(() => false),
+                            getSetting: jest.fn(() => "null"),
+                            memberOnoffWatchers: new Map(),
+                        }]),
+                    },
+                })),
+            },
+        };
+
+        const result = app.collectDeviceDiagnostics();
+
+        expect(result.clgGroups).toEqual([expect.objectContaining({
+            totalMembers: 0,
+            enabledMembers: 0,
+            updateIntervalSeconds: 120,
+        })]);
+        expect(result.collectionErrors).toContain("A Circadian Light Group has a non-object configuration.");
+    });
 });

--- a/no.tiwas.booleantoolbox/AppDiagnostics.test.js
+++ b/no.tiwas.booleantoolbox/AppDiagnostics.test.js
@@ -93,7 +93,8 @@ describe("BooleanToolboxApp diagnostics", () => {
         expect(payload.report).toContain("Homey-reported app memory: 48.0 MB");
         expect(payload.report).not.toContain("Private bedroom");
         expect(payload.report).not.toContain("secret-light-id");
-        expect(issueUrl.searchParams.get("logs")).toBe(payload.report);
+        expect(issueUrl.searchParams.get("body")).toContain(payload.report);
+        expect(issueUrl.searchParams.get("body")).toContain("## App version\n\n1.10.28");
         expect(issueUrl.searchParams.get("title")).toBe("[Bug]: Group resets");
     });
 

--- a/no.tiwas.booleantoolbox/AppDiagnostics.test.js
+++ b/no.tiwas.booleantoolbox/AppDiagnostics.test.js
@@ -1,0 +1,120 @@
+"use strict";
+
+jest.mock("homey", () => ({
+    App: class {},
+    manifest: { version: "1.10.28" },
+}), { virtual: true });
+
+jest.mock("./lib/Logger", () => class MockLogger {});
+jest.mock("./lib/WaiterManager", () => jest.fn());
+jest.mock("./lib/CapturedStateManager", () => jest.fn());
+
+const BooleanToolboxApp = require("./app");
+
+function createSettings(values = {}) {
+    return {
+        get: jest.fn((key) => values[key]),
+        set: jest.fn(async (key, value) => {
+            values[key] = value;
+        }),
+    };
+}
+
+describe("BooleanToolboxApp diagnostics", () => {
+    test("collects anonymous device and resource load and returns a GitHub issue URL", async () => {
+        const app = new BooleanToolboxApp();
+        const settings = createSettings({
+            debug_mode: true,
+            device_registry: { currentCount: 70, knownCount: 72, missingCount: 2 },
+        });
+        const group = {
+            hasCapability: jest.fn(() => true),
+            getCapabilityValue: jest.fn((capability) => capability === "clg_paused" ? false : true),
+            getSetting: jest.fn(() => JSON.stringify({
+                profile: { updateIntervalSeconds: 30, transitionSeconds: 20 },
+                devices: [
+                    { id: "secret-light-id", name: "Private bedroom", enabled: true },
+                    { id: "other-light-id", name: "Private kitchen", enabled: false },
+                ],
+            })),
+            memberOnoffWatchers: new Map([["secret-light-id", {}]]),
+        };
+        app.homey = {
+            manifest: { version: "1.10.28" },
+            settings,
+            drivers: {
+                getDrivers: jest.fn(() => ({
+                    "circadian-light-group": {
+                        id: "circadian-light-group",
+                        getDevices: jest.fn(() => [group]),
+                    },
+                    "logic-device": {
+                        id: "logic-device",
+                        getDevices: jest.fn(() => []),
+                    },
+                })),
+            },
+        };
+        app.api = {
+            system: {
+                getInfo: jest.fn().mockResolvedValue({
+                    loadavg: [0.25, 0.2, 0.1],
+                    totalmem: 2 * 1024 * 1024 * 1024,
+                    freemem: 512 * 1024 * 1024,
+                }),
+                getMemoryInfo: jest.fn().mockResolvedValue(null),
+                getStorageInfo: jest.fn().mockResolvedValue({
+                    root: {
+                        total: 8 * 1024 * 1024 * 1024,
+                        free: 2 * 1024 * 1024 * 1024,
+                    },
+                }),
+            },
+            apps: {
+                getApp: jest.fn().mockResolvedValue({
+                    state: "running",
+                    crashedCount: 0,
+                    usage: { cpu: 0.001, mem: 48 * 1024 * 1024 },
+                }),
+            },
+        };
+        app.startedAt = new Date(Date.now() - 60000);
+        app.diagnosticEvents = [];
+
+        const payload = await app.getDiagnosticsPayload("Group resets");
+        const issueUrl = new URL(payload.issueUrl);
+
+        expect(payload.appVersion).toBe("1.10.28");
+        expect(payload.report).toContain("App devices: 1");
+        expect(payload.report).toContain("1/2 members enabled");
+        expect(payload.report).toContain("update 30s");
+        expect(payload.report).toContain("Homey system load average (1 / 5 / 15 min): 0.25 / 0.20 / 0.10");
+        expect(payload.report).toContain("Homey storage: 6144.0 MB used of 8192.0 MB");
+        expect(payload.report).toContain("Homey-reported app memory: 48.0 MB");
+        expect(payload.report).not.toContain("Private bedroom");
+        expect(payload.report).not.toContain("secret-light-id");
+        expect(issueUrl.searchParams.get("logs")).toBe(payload.report);
+        expect(issueUrl.searchParams.get("title")).toBe("[Bug]: Group resets");
+    });
+
+    test("keeps only sanitized persisted warning and error events", async () => {
+        jest.useFakeTimers();
+        const app = new BooleanToolboxApp();
+        const settings = createSettings({});
+        app.homey = { settings };
+        app.diagnosticEvents = [];
+        app.diagnosticPersistTimer = null;
+
+        app.recordDiagnosticEvent({
+            level: "ERROR",
+            category: "Test",
+            message: "Failed 123e4567-e89b-12d3-a456-426614174000",
+        });
+        await jest.runAllTimersAsync();
+
+        expect(app.diagnosticEvents).toHaveLength(1);
+        expect(app.diagnosticEvents[0].message).toContain("<redacted-id>");
+        expect(settings.set).toHaveBeenCalledWith("diagnostic_events", app.diagnosticEvents);
+        jest.useRealTimers();
+    });
+});

--- a/no.tiwas.booleantoolbox/CircadianLightGroupDevice.test.js
+++ b/no.tiwas.booleantoolbox/CircadianLightGroupDevice.test.js
@@ -33,6 +33,22 @@ function setable(value) {
 }
 
 describe('CircadianLightGroupDevice capability selection', () => {
+  test('captures an anonymous app diagnostic with an error stack', () => {
+    const device = createDeviceHarness();
+    const recordDiagnosticEvent = jest.fn();
+    device.homey = { app: { recordDiagnosticEvent } };
+    const error = new Error('member failed');
+
+    device.recordAppDiagnostic('ERROR', 'Circadian member update failed.', error);
+
+    expect(recordDiagnosticEvent).toHaveBeenCalledWith(expect.objectContaining({
+      level: 'ERROR',
+      category: 'CircadianLightGroup',
+      message: 'Circadian member update failed.',
+      stack: expect.stringContaining('Error: member failed'),
+    }));
+  });
+
   test('does not switch to color mode when red target cannot write hue and saturation', () => {
     const device = createDeviceHarness();
     const writes = device.getCapabilitiesToSet(

--- a/no.tiwas.booleantoolbox/CircadianLightGroupDevice.test.js
+++ b/no.tiwas.booleantoolbox/CircadianLightGroupDevice.test.js
@@ -45,8 +45,9 @@ describe('CircadianLightGroupDevice capability selection', () => {
       level: 'ERROR',
       category: 'CircadianLightGroup',
       message: 'Circadian member update failed.',
-      stack: expect.stringContaining('Error: member failed'),
+      stack: expect.stringContaining('at '),
     }));
+    expect(recordDiagnosticEvent.mock.calls[0][0].stack).not.toContain('member failed');
   });
 
   test('does not switch to color mode when red target cannot write hue and saturation', () => {

--- a/no.tiwas.booleantoolbox/DiagnosticsApi.test.js
+++ b/no.tiwas.booleantoolbox/DiagnosticsApi.test.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const api = require("./api");
+
+describe("diagnostics settings API", () => {
+    test("delegates report creation to the app with the issue summary", async () => {
+        const getDiagnosticsPayload = jest.fn(() => ({ report: "ok" }));
+        const result = await api.getDiagnostics({
+            homey: { app: { getDiagnosticsPayload } },
+            body: { summary: "Lights reset" },
+        });
+
+        expect(getDiagnosticsPayload).toHaveBeenCalledWith("Lights reset");
+        expect(result).toEqual({ report: "ok" });
+    });
+});

--- a/no.tiwas.booleantoolbox/DiagnosticsReport.test.js
+++ b/no.tiwas.booleantoolbox/DiagnosticsReport.test.js
@@ -10,7 +10,8 @@ describe("DiagnosticsReport", () => {
     test("redacts common private identifiers and credentials", () => {
         const value = redactDiagnosticText(
             "device 123e4567-e89b-12d3-a456-426614174000 at 192.168.1.12 " +
-            "for owner@example.com token=super-secret Bearer abc.def.ghi",
+            "for owner@example.com token=super-secret Bearer abc.def.ghi " +
+            "{\"password\":\"hunter two\"}; secret=two word value; done",
         );
 
         expect(value).toContain("<redacted-id>");
@@ -20,6 +21,8 @@ describe("DiagnosticsReport", () => {
         expect(value).toContain("Bearer <redacted-token>");
         expect(value).not.toContain("123e4567-e89b-12d3-a456-426614174000");
         expect(value).not.toContain("super-secret");
+        expect(value).not.toContain("hunter two");
+        expect(value).not.toContain("two word value");
     });
 
     test("builds a bounded report with device and Circadian load details", () => {
@@ -63,7 +66,7 @@ describe("DiagnosticsReport", () => {
         expect(report.length).toBeLessThanOrEqual(1800);
     });
 
-    test("creates a prefilled GitHub issue form URL", () => {
+    test("creates a prefilled GitHub issue URL with standard query parameters", () => {
         const url = new URL(buildGitHubIssueUrl({
             appVersion: "1.10.28",
             report: "diagnostic body",
@@ -72,10 +75,31 @@ describe("DiagnosticsReport", () => {
 
         expect(url.origin).toBe("https://github.com");
         expect(url.pathname).toBe("/Tiwas/SmartComponentsToolkit/issues/new");
-        expect(url.searchParams.get("template")).toBe("01-bug-report.yml");
-        expect(url.searchParams.get("app-version")).toBe("1.10.28");
-        expect(url.searchParams.get("logs")).toBe("diagnostic body");
+        expect(url.searchParams.has("template")).toBe(false);
+        expect(url.searchParams.has("app-version")).toBe(false);
+        expect(url.searchParams.has("logs")).toBe(false);
         expect(url.searchParams.get("title")).toBe("[Bug]: Resets every 30 seconds ignored line break");
+        expect(url.searchParams.get("body")).toContain("## App version\n\n1.10.28");
+        expect(url.searchParams.get("body")).toContain("## Diagnostic report\n\ndiagnostic body");
+    });
+
+    test("keeps the newest diagnostic event when a long report must be shortened", () => {
+        const report = buildDiagnosticsReport({
+            appVersion: "1.10.28",
+            deviceSummary: {
+                drivers: Array.from({ length: 30 }, (_, index) => ({ id: `driver-${index}`, count: index })),
+            },
+            events: [
+                { timestamp: "2026-09-06T10:00:00.000Z", level: "ERROR", message: "OLDEST-EVENT", stack: Array(80).fill("at oldest-file.js:1:1").join("\n") },
+                { timestamp: "2026-09-06T10:01:00.000Z", level: "ERROR", message: "MIDDLE-EVENT", stack: Array(80).fill("at middle-file.js:1:1").join("\n") },
+                { timestamp: "2026-09-06T10:02:00.000Z", level: "ERROR", message: "NEWEST-EVENT", stack: Array(80).fill("at newest-file.js:1:1").join("\n") },
+            ],
+        }, { maxReportLength: 1800 });
+
+        expect(report).toContain("NEWEST-EVENT");
+        expect(report).not.toContain("OLDEST-EVENT");
+        expect(report).toContain("Privacy notice");
+        expect(report.length).toBeLessThanOrEqual(1800);
     });
 
     test("marks unavailable resource metrics instead of reporting zero", () => {

--- a/no.tiwas.booleantoolbox/DiagnosticsReport.test.js
+++ b/no.tiwas.booleantoolbox/DiagnosticsReport.test.js
@@ -1,0 +1,95 @@
+"use strict";
+
+const {
+    buildDiagnosticsReport,
+    buildGitHubIssueUrl,
+    redactDiagnosticText,
+} = require("./lib/DiagnosticsReport");
+
+describe("DiagnosticsReport", () => {
+    test("redacts common private identifiers and credentials", () => {
+        const value = redactDiagnosticText(
+            "device 123e4567-e89b-12d3-a456-426614174000 at 192.168.1.12 " +
+            "for owner@example.com token=super-secret Bearer abc.def.ghi",
+        );
+
+        expect(value).toContain("<redacted-id>");
+        expect(value).toContain("<redacted-ip>");
+        expect(value).toContain("<redacted-email>");
+        expect(value).toContain("token=<redacted>");
+        expect(value).toContain("Bearer <redacted-token>");
+        expect(value).not.toContain("123e4567-e89b-12d3-a456-426614174000");
+        expect(value).not.toContain("super-secret");
+    });
+
+    test("builds a bounded report with device and Circadian load details", () => {
+        const report = buildDiagnosticsReport({
+            generatedAt: "2026-09-06T20:00:00.000Z",
+            appVersion: "1.10.28",
+            nodeVersion: "v22.0.0",
+            startedAt: "2026-09-06T19:00:00.000Z",
+            uptimeSeconds: 3600,
+            debugMode: true,
+            memory: { rss: 50 * 1024 * 1024, heapUsed: 10 * 1024 * 1024, heapTotal: 20 * 1024 * 1024 },
+            deviceSummary: {
+                total: 5,
+                configAlarms: 1,
+                drivers: [{ id: "circadian-light-group", count: 2 }],
+            },
+            registry: { currentCount: 42, knownCount: 45, missingCount: 3 },
+            clgGroups: [{
+                totalMembers: 12,
+                enabledMembers: 10,
+                updateIntervalSeconds: 30,
+                transitionSeconds: 20,
+                watchers: 10,
+                paused: false,
+            }],
+            events: [{
+                timestamp: "2026-09-06T19:59:00.000Z",
+                level: "ERROR",
+                category: "Device",
+                message: "Failed device 123e4567-e89b-12d3-a456-426614174000",
+                stack: "Error: failed\n    at test.js:1:1",
+            }],
+        }, { maxReportLength: 1800 });
+
+        expect(report).toContain("App version: 1.10.28");
+        expect(report).toContain("App devices: 5");
+        expect(report).toContain("10/12 members enabled");
+        expect(report).toContain("update 30s");
+        expect(report).toContain("<redacted-id>");
+        expect(report).toContain("Error: failed");
+        expect(report.length).toBeLessThanOrEqual(1800);
+    });
+
+    test("creates a prefilled GitHub issue form URL", () => {
+        const url = new URL(buildGitHubIssueUrl({
+            appVersion: "1.10.28",
+            report: "diagnostic body",
+            summary: "Resets every 30 seconds\nignored line break",
+        }));
+
+        expect(url.origin).toBe("https://github.com");
+        expect(url.pathname).toBe("/Tiwas/SmartComponentsToolkit/issues/new");
+        expect(url.searchParams.get("template")).toBe("01-bug-report.yml");
+        expect(url.searchParams.get("app-version")).toBe("1.10.28");
+        expect(url.searchParams.get("logs")).toBe("diagnostic body");
+        expect(url.searchParams.get("title")).toBe("[Bug]: Resets every 30 seconds ignored line break");
+    });
+
+    test("marks unavailable resource metrics instead of reporting zero", () => {
+        const report = buildDiagnosticsReport({
+            systemResources: {
+                appCpu: null,
+                appMemory: null,
+                storageTotal: null,
+                storageFree: null,
+            },
+        });
+
+        expect(report).toContain("Homey-reported app memory: unavailable");
+        expect(report).toContain("Homey-reported app CPU metric: unavailable");
+        expect(report).toContain("Homey storage: unavailable used of unavailable");
+    });
+});

--- a/no.tiwas.booleantoolbox/LoggerDiagnostics.test.js
+++ b/no.tiwas.booleantoolbox/LoggerDiagnostics.test.js
@@ -19,8 +19,9 @@ describe("Logger diagnostics capture", () => {
         logger.debug("debug message");
         logger.warn("warning message");
         logger.error("error message", error);
+        logger.error(error);
 
-        expect(recordDiagnosticEvent).toHaveBeenCalledTimes(2);
+        expect(recordDiagnosticEvent).toHaveBeenCalledTimes(3);
         expect(recordDiagnosticEvent).toHaveBeenNthCalledWith(1, expect.objectContaining({
             level: "WARN",
             category: "Test",
@@ -29,6 +30,11 @@ describe("Logger diagnostics capture", () => {
         expect(recordDiagnosticEvent).toHaveBeenNthCalledWith(2, expect.objectContaining({
             level: "ERROR",
             message: "error message",
+            stack: expect.stringContaining("Error: failure"),
+        }));
+        expect(recordDiagnosticEvent).toHaveBeenNthCalledWith(3, expect.objectContaining({
+            level: "ERROR",
+            message: "failure",
             stack: expect.stringContaining("Error: failure"),
         }));
     });

--- a/no.tiwas.booleantoolbox/LoggerDiagnostics.test.js
+++ b/no.tiwas.booleantoolbox/LoggerDiagnostics.test.js
@@ -1,0 +1,35 @@
+"use strict";
+
+const Logger = require("./lib/Logger");
+
+describe("Logger diagnostics capture", () => {
+    test("captures warnings and errors, including error stack traces", () => {
+        const recordDiagnosticEvent = jest.fn();
+        const homey = {
+            __: jest.fn((key) => key),
+            app: {
+                log: jest.fn(),
+                error: jest.fn(),
+                recordDiagnosticEvent,
+            },
+        };
+        const logger = new Logger({ homey }, "Test", { level: "DEBUG" });
+        const error = new Error("failure");
+
+        logger.debug("debug message");
+        logger.warn("warning message");
+        logger.error("error message", error);
+
+        expect(recordDiagnosticEvent).toHaveBeenCalledTimes(2);
+        expect(recordDiagnosticEvent).toHaveBeenNthCalledWith(1, expect.objectContaining({
+            level: "WARN",
+            category: "Test",
+            message: "warning message",
+        }));
+        expect(recordDiagnosticEvent).toHaveBeenNthCalledWith(2, expect.objectContaining({
+            level: "ERROR",
+            message: "error message",
+            stack: expect.stringContaining("Error: failure"),
+        }));
+    });
+});

--- a/no.tiwas.booleantoolbox/LoggerDiagnostics.test.js
+++ b/no.tiwas.booleantoolbox/LoggerDiagnostics.test.js
@@ -25,17 +25,21 @@ describe("Logger diagnostics capture", () => {
         expect(recordDiagnosticEvent).toHaveBeenNthCalledWith(1, expect.objectContaining({
             level: "WARN",
             category: "Test",
-            message: "warning message",
+            message: "Warning recorded.",
         }));
         expect(recordDiagnosticEvent).toHaveBeenNthCalledWith(2, expect.objectContaining({
             level: "ERROR",
-            message: "error message",
-            stack: expect.stringContaining("Error: failure"),
+            message: "Error recorded.",
+            stack: expect.stringContaining("at "),
         }));
         expect(recordDiagnosticEvent).toHaveBeenNthCalledWith(3, expect.objectContaining({
             level: "ERROR",
-            message: "failure",
-            stack: expect.stringContaining("Error: failure"),
+            message: "Error recorded.",
+            stack: expect.stringContaining("at "),
         }));
+        expect(recordDiagnosticEvent.mock.calls[1][0].stack).not.toContain("failure");
+        expect(recordDiagnosticEvent.mock.calls[2][0].stack).not.toContain("failure");
+        expect(JSON.stringify(recordDiagnosticEvent.mock.calls)).not.toContain("warning message");
+        expect(JSON.stringify(recordDiagnosticEvent.mock.calls)).not.toContain("error message");
     });
 });

--- a/no.tiwas.booleantoolbox/README.txt
+++ b/no.tiwas.booleantoolbox/README.txt
@@ -42,6 +42,14 @@ State Device
 Legacy Logic Unit X (2-10 inputs)
   Existing fixed-input Logic Unit devices remain supported but are deprecated. Use Logic Unit (Dynamic) or Logic Device for new setups.
 
+== DIAGNOSTICS AND SUPPORT ==
+
+Generate a privacy-conscious diagnostic report from App Settings and open the GitHub bug form with the report prefilled.
+  - Includes app version, uptime, recent warnings/errors, and stack traces
+  - Shows anonymous app-device and Circadian Light Group load counts
+  - Includes available app/Homey CPU, memory, and storage information
+  - Redacts common identifiers and secrets; nothing is uploaded automatically
+
 == STANDALONE FLOW CARDS ==
 
 Conditional Gates

--- a/no.tiwas.booleantoolbox/SettingsDiagnostics.test.js
+++ b/no.tiwas.booleantoolbox/SettingsDiagnostics.test.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+describe("settings diagnostics UI", () => {
+    test("opens the diagnostic payload that the user already reviewed", () => {
+        const html = fs.readFileSync(path.join(__dirname, "settings", "index.html"), "utf8");
+        const handlerStart = html.indexOf("openGitHubIssueButton.addEventListener");
+        const handlerEnd = html.indexOf("saveButton.addEventListener", handlerStart);
+        const handler = html.slice(handlerStart, handlerEnd);
+
+        expect(handler).toContain("Homey.openURL(diagnosticsPayload.issueUrl)");
+        expect(handler).not.toContain("await generateDiagnostics()");
+    });
+});

--- a/no.tiwas.booleantoolbox/api.js
+++ b/no.tiwas.booleantoolbox/api.js
@@ -1,0 +1,10 @@
+"use strict";
+
+module.exports = {
+    async getDiagnostics({ homey, body }) {
+        const summary = body && typeof body.summary === "string"
+            ? body.summary
+            : "";
+        return await homey.app.getDiagnosticsPayload(summary);
+    },
+};

--- a/no.tiwas.booleantoolbox/app.js
+++ b/no.tiwas.booleantoolbox/app.js
@@ -358,12 +358,19 @@ module.exports = class BooleanToolboxApp extends Homey.App {
 
                 let config = {};
                 try {
-                    config = JSON.parse(device.getSetting("config_json") || "{}");
+                    const parsedConfig = JSON.parse(device.getSetting("config_json") || "{}");
+                    if (!parsedConfig || typeof parsedConfig !== "object" || Array.isArray(parsedConfig)) {
+                        collectionErrors.push("A Circadian Light Group has a non-object configuration.");
+                    } else {
+                        config = parsedConfig;
+                    }
                 } catch (error) {
                     collectionErrors.push("A Circadian Light Group has invalid configuration JSON.");
                 }
                 const members = Array.isArray(config.devices) ? config.devices : [];
-                const profile = config.profile || {};
+                const profile = config.profile && typeof config.profile === "object" && !Array.isArray(config.profile)
+                    ? config.profile
+                    : {};
                 let paused = false;
                 try {
                     paused = device.getCapabilityValue("clg_paused") === true;

--- a/no.tiwas.booleantoolbox/app.js
+++ b/no.tiwas.booleantoolbox/app.js
@@ -1,9 +1,16 @@
 "use strict";
 
 const Homey = require("homey");
+const os = require("node:os");
 const Logger = require("./lib/Logger");
 const WaiterManager = require("./lib/WaiterManager");
 const CapturedStateManager = require("./lib/CapturedStateManager");
+const {
+    buildDiagnosticsReport,
+    buildGitHubIssueUrl,
+    redactDiagnosticText,
+    sanitizeEvent,
+} = require("./lib/DiagnosticsReport");
 const {
     compareNumbers,
     evaluateNumericComparison,
@@ -18,6 +25,16 @@ const DEVICE_REGISTRY_DEFAULT_RETENTION_MONTHS = 12;
 const DEVICE_REGISTRY_REFRESH_INTERVAL_MS = 6 * 60 * 60 * 1000;
 const HOMEY_API_MANAGER_MAX_LISTENERS = 50;
 const API_DEVICES_CACHE_TTL_MS = 1000;
+const DIAGNOSTIC_EVENTS_KEY = "diagnostic_events";
+const DIAGNOSTIC_EVENTS_LIMIT = 40;
+const DIAGNOSTIC_PERSIST_DELAY_MS = 2000;
+
+function isFiniteDiagnosticMetric(value) {
+    return value !== null
+        && value !== undefined
+        && value !== ""
+        && Number.isFinite(Number(value));
+}
 
 /**
  * Helper function for evaluate_expression action card.
@@ -147,9 +164,12 @@ module.exports = class BooleanToolboxApp extends Homey.App {
      *   - BooleanToolboxApp.registerAllFlowCards()
      */
     async onInit() {
+        this.startedAt = new Date();
+        this.diagnosticEvents = this.loadDiagnosticEvents();
+        this.diagnosticPersistTimer = null;
         this.logger = new Logger(this, "App");
         try {
-            const version = require("./package.json").version;
+            const version = this.getAppVersion();
             this.logger.banner(`BOOLEAN TOOLBOX v${version}`);
         } catch (e) {
             this.logger.error(
@@ -237,7 +257,238 @@ module.exports = class BooleanToolboxApp extends Homey.App {
         if (this.waiterManager) {
             this.waiterManager.destroy();
         }
+        await this.persistDiagnosticEvents();
         this.logger.info("App uninitialized.", {});
+    }
+
+    getAppVersion() {
+        return this.homey?.manifest?.version
+            || Homey.manifest?.version
+            || require("./package.json").version
+            || "unknown";
+    }
+
+    loadDiagnosticEvents() {
+        let storedEvents;
+        try {
+            storedEvents = this.homey.settings.get(DIAGNOSTIC_EVENTS_KEY);
+        } catch (error) {
+            return [];
+        }
+        if (!Array.isArray(storedEvents)) return [];
+
+        return storedEvents
+            .map(sanitizeEvent)
+            .filter(Boolean)
+            .slice(-DIAGNOSTIC_EVENTS_LIMIT);
+    }
+
+    recordDiagnosticEvent(event) {
+        const sanitized = sanitizeEvent({
+            ...event,
+            timestamp: event?.timestamp || new Date().toISOString(),
+        });
+        if (!sanitized) return;
+
+        this.diagnosticEvents = Array.isArray(this.diagnosticEvents)
+            ? this.diagnosticEvents
+            : [];
+        this.diagnosticEvents.push(sanitized);
+        this.diagnosticEvents = this.diagnosticEvents.slice(-DIAGNOSTIC_EVENTS_LIMIT);
+
+        if (this.diagnosticPersistTimer) return;
+        this.diagnosticPersistTimer = setTimeout(() => {
+            this.diagnosticPersistTimer = null;
+            this.persistDiagnosticEvents().catch((error) => {
+                console.error("Failed to persist diagnostic events", error);
+            });
+        }, DIAGNOSTIC_PERSIST_DELAY_MS);
+    }
+
+    async persistDiagnosticEvents() {
+        if (this.diagnosticPersistTimer) {
+            clearTimeout(this.diagnosticPersistTimer);
+            this.diagnosticPersistTimer = null;
+        }
+        await this.homey.settings.set(
+            DIAGNOSTIC_EVENTS_KEY,
+            (this.diagnosticEvents || []).slice(-DIAGNOSTIC_EVENTS_LIMIT),
+        );
+    }
+
+    collectDeviceDiagnostics() {
+        const summary = {
+            total: 0,
+            configAlarms: 0,
+            drivers: [],
+        };
+        const clgGroups = [];
+        const collectionErrors = [];
+
+        let driverEntries = [];
+        try {
+            driverEntries = Object.entries(this.homey.drivers.getDrivers() || {});
+        } catch (error) {
+            collectionErrors.push(`Could not enumerate app drivers: ${error.message}`);
+        }
+
+        for (const [driverKey, driver] of driverEntries) {
+            const driverId = String(driver?.id || driverKey || "unknown");
+            let devices = [];
+            try {
+                const driverDevices = driver.getDevices();
+                devices = Array.isArray(driverDevices) ? driverDevices : [];
+            } catch (error) {
+                collectionErrors.push(`Could not inspect driver ${redactDiagnosticText(driverId)}: ${error.message}`);
+            }
+
+            summary.total += devices.length;
+            summary.drivers.push({ id: driverId, count: devices.length });
+
+            for (const device of devices) {
+                try {
+                    if (device.hasCapability?.("alarm_config") && device.getCapabilityValue("alarm_config") === true) {
+                        summary.configAlarms += 1;
+                    }
+                } catch (error) {
+                    collectionErrors.push(`Could not read a configuration alarm for driver ${redactDiagnosticText(driverId)}.`);
+                }
+
+                if (driverId !== "circadian-light-group") continue;
+
+                let config = {};
+                try {
+                    config = JSON.parse(device.getSetting("config_json") || "{}");
+                } catch (error) {
+                    collectionErrors.push("A Circadian Light Group has invalid configuration JSON.");
+                }
+                const members = Array.isArray(config.devices) ? config.devices : [];
+                const profile = config.profile || {};
+                let paused = false;
+                try {
+                    paused = device.getCapabilityValue("clg_paused") === true;
+                } catch (error) {}
+
+                clgGroups.push({
+                    totalMembers: members.length,
+                    enabledMembers: members.filter((member) => member.enabled !== false).length,
+                    updateIntervalSeconds: Math.max(30, Number(profile.updateIntervalSeconds) || 120),
+                    transitionSeconds: Math.max(0, Number(profile.transitionSeconds) || 0),
+                    watchers: Number(device.memberOnoffWatchers?.size) || 0,
+                    paused,
+                });
+            }
+        }
+
+        summary.drivers.sort((a, b) => a.id.localeCompare(b.id));
+        return { summary, clgGroups, collectionErrors };
+    }
+
+    async collectResourceDiagnostics() {
+        const systemResources = {
+            cpuCores: os.cpus().length || null,
+            loadAverage: os.loadavg(),
+            memoryTotal: os.totalmem(),
+            memoryFree: os.freemem(),
+            storageTotal: null,
+            storageFree: null,
+            appCpu: null,
+            appMemory: null,
+            appState: null,
+            crashedCount: null,
+            crashedMessage: null,
+        };
+
+        let api;
+        try {
+            api = await this.ensureHomeyApi();
+        } catch (error) {
+            return systemResources;
+        }
+
+        const calls = [
+            typeof api.system?.getInfo === "function" ? api.system.getInfo() : Promise.resolve(null),
+            typeof api.system?.getMemoryInfo === "function" ? api.system.getMemoryInfo() : Promise.resolve(null),
+            typeof api.system?.getStorageInfo === "function" ? api.system.getStorageInfo() : Promise.resolve(null),
+            typeof api.apps?.getApp === "function"
+                ? api.apps.getApp({ id: "no.tiwas.booleantoolbox" })
+                : Promise.resolve(null),
+        ];
+        const [infoResult, memoryResult, storageResult, appResult] = await Promise.allSettled(calls);
+
+        if (infoResult.status === "fulfilled" && infoResult.value) {
+            const info = infoResult.value;
+            if (Array.isArray(info.loadavg)) systemResources.loadAverage = info.loadavg;
+            if (isFiniteDiagnosticMetric(info.totalmem)) systemResources.memoryTotal = Number(info.totalmem);
+            if (isFiniteDiagnosticMetric(info.freemem)) systemResources.memoryFree = Number(info.freemem);
+        }
+
+        if (memoryResult.status === "fulfilled" && memoryResult.value) {
+            const memory = memoryResult.value;
+            if (isFiniteDiagnosticMetric(memory.total)) {
+                const used = Array.isArray(memory.types)
+                    ? memory.types.reduce((total, item) => total + (Number(item?.size) || 0), 0)
+                    : null;
+                systemResources.memoryTotal = Number(memory.total);
+                if (used !== null) systemResources.memoryFree = Math.max(0, Number(memory.total) - used);
+            }
+        }
+
+        if (storageResult.status === "fulfilled" && storageResult.value) {
+            const storage = storageResult.value.root || storageResult.value;
+            if (isFiniteDiagnosticMetric(storage.total)) systemResources.storageTotal = Number(storage.total);
+            if (isFiniteDiagnosticMetric(storage.free)) systemResources.storageFree = Number(storage.free);
+        }
+
+        if (appResult.status === "fulfilled" && appResult.value) {
+            const appInfo = appResult.value;
+            if (isFiniteDiagnosticMetric(appInfo.usage?.cpu)) {
+                systemResources.appCpu = Number(appInfo.usage.cpu);
+            }
+            if (isFiniteDiagnosticMetric(appInfo.usage?.mem)) {
+                systemResources.appMemory = Number(appInfo.usage.mem);
+            }
+            systemResources.appState = appInfo.state || null;
+            systemResources.crashedCount = isFiniteDiagnosticMetric(appInfo.crashedCount)
+                ? Number(appInfo.crashedCount)
+                : null;
+            systemResources.crashedMessage = appInfo.crashedMessage || null;
+        }
+
+        return systemResources;
+    }
+
+    async getDiagnosticsPayload(summary = "") {
+        const appVersion = this.getAppVersion();
+        const deviceDiagnostics = this.collectDeviceDiagnostics();
+        const systemResources = await this.collectResourceDiagnostics();
+        const registry = this.homey.settings.get(DEVICE_REGISTRY_KEY) || {};
+        const startedAt = this.startedAt instanceof Date
+            ? this.startedAt
+            : new Date(this.startedAt || Date.now());
+        const generatedAt = new Date();
+        const report = buildDiagnosticsReport({
+            appVersion,
+            generatedAt: generatedAt.toISOString(),
+            startedAt: startedAt.toISOString(),
+            uptimeSeconds: Math.max(0, (generatedAt.getTime() - startedAt.getTime()) / 1000),
+            nodeVersion: process.version,
+            debugMode: this.homey.settings.get("debug_mode") === true,
+            memory: process.memoryUsage(),
+            systemResources,
+            deviceSummary: deviceDiagnostics.summary,
+            clgGroups: deviceDiagnostics.clgGroups,
+            collectionErrors: deviceDiagnostics.collectionErrors,
+            registry,
+            events: this.diagnosticEvents,
+        });
+
+        return {
+            appVersion,
+            generatedAt: generatedAt.toISOString(),
+            report,
+            issueUrl: buildGitHubIssueUrl({ appVersion, report, summary }),
+        };
     }
 
     async createHomeyApi() {

--- a/no.tiwas.booleantoolbox/drivers/circadian-light-group/device.js
+++ b/no.tiwas.booleantoolbox/drivers/circadian-light-group/device.js
@@ -104,6 +104,23 @@ class CircadianLightGroupDevice extends Homey.Device {
     await this.startScheduler(true);
   }
 
+  recordAppDiagnostic(level, message, error) {
+    const recorder = this.homey?.app?.recordDiagnosticEvent;
+    if (typeof recorder !== 'function') return;
+
+    try {
+      recorder.call(this.homey.app, {
+        timestamp: new Date().toISOString(),
+        level,
+        category: 'CircadianLightGroup',
+        message,
+        stack: error instanceof Error ? error.stack : '',
+      });
+    } catch (recordingError) {
+      this.debug(`Diagnostic capture failed: ${recordingError.message}`);
+    }
+  }
+
   async onPausedCapabilityChanged(value) {
     this.pauseDebug(`capability changed value=${value}`);
     this.clearPauseTimer();
@@ -525,6 +542,7 @@ class CircadianLightGroupDevice extends Homey.Device {
     try {
       return JSON.parse(json);
     } catch (error) {
+      this.recordAppDiagnostic('ERROR', 'Invalid Circadian Light Group configuration JSON.', error);
       this.setCapabilityValue('alarm_config', true).catch(this.error);
       this.triggerError(`Invalid Circadian Light Group JSON: ${error.message}`).catch(this.error);
       return { profile: {}, outdoorLight: {}, devices: [] };
@@ -544,6 +562,7 @@ class CircadianLightGroupDevice extends Homey.Device {
 
     this.timer = setInterval(() => {
       this.applyCurrentProfile({ reason: 'timer' }).catch(error => {
+        this.recordAppDiagnostic('ERROR', 'Scheduled Circadian Light Group update failed.', error);
         this.error('Circadian apply failed:', error);
       });
     }, intervalMs);
@@ -579,6 +598,7 @@ class CircadianLightGroupDevice extends Homey.Device {
     try {
       outdoor = await this.outdoorProvider.getOutdoorLight(config.outdoorLight || {});
     } catch (error) {
+      this.recordAppDiagnostic('ERROR', 'Circadian outdoor-light lookup failed; using fallback.', error);
       this.error('Failed to resolve outdoor light, using astronomical fallback:', error);
       outdoor = await this.outdoorProvider.getAstronomical(config.outdoorLight || {}, new Date(), 'fallback-after-error');
     }
@@ -639,6 +659,14 @@ class CircadianLightGroupDevice extends Homey.Device {
 
     if (superseded) return false;
 
+    failed.slice(0, 3).forEach((failure) => {
+      this.recordAppDiagnostic(
+        'ERROR',
+        `Circadian member update failed during ${reason}.`,
+        failure.error,
+      );
+    });
+
     const nonTransientFailures = failed.filter(res => !isTransientDeviceError(res.error));
     await this.setCapabilityValue('alarm_config', nonTransientFailures.length > 0).catch(this.error);
 
@@ -697,7 +725,10 @@ class CircadianLightGroupDevice extends Homey.Device {
 
     Promise.resolve()
       .then(() => this.applyCurrentProfile({ reason: `deferred-${deferredReason}` }))
-      .catch(error => this.error('Deferred Circadian apply failed:', error));
+      .catch(error => {
+        this.recordAppDiagnostic('ERROR', 'Deferred Circadian Light Group update failed.', error);
+        this.error('Deferred Circadian apply failed:', error);
+      });
   }
 
   // Run an async task per device with staged backoff:
@@ -1056,6 +1087,10 @@ class CircadianLightGroupDevice extends Homey.Device {
       .map(res => res.item?.name || res.item?.id || '<unknown>')
       .join(', ');
     this.debug(`${label}: ${failed.length} member(s) not verified ${expectedDescription}: ${names}`);
+    this.recordAppDiagnostic(
+      'WARN',
+      `${failed.length} Circadian member(s) could not be verified ${expectedDescription}.`,
+    );
     await this.setCapabilityValue('alarm_config', true).catch(this.error);
     await this.triggerError(`${label}: ${failed.length} light(s) not verified ${expectedDescription}: ${names}`);
     return false;

--- a/no.tiwas.booleantoolbox/drivers/circadian-light-group/device.js
+++ b/no.tiwas.booleantoolbox/drivers/circadian-light-group/device.js
@@ -108,13 +108,17 @@ class CircadianLightGroupDevice extends Homey.Device {
     const recorder = this.homey?.app?.recordDiagnosticEvent;
     if (typeof recorder !== 'function') return;
 
+    const stack = error instanceof Error && typeof error.stack === 'string'
+      ? error.stack.split(/\r?\n/).slice(1).join('\n')
+      : '';
+
     try {
       recorder.call(this.homey.app, {
         timestamp: new Date().toISOString(),
         level,
         category: 'CircadianLightGroup',
         message,
-        stack: error instanceof Error ? error.stack : '',
+        stack,
       });
     } catch (recordingError) {
       this.debug(`Diagnostic capture failed: ${recordingError.message}`);

--- a/no.tiwas.booleantoolbox/lib/DiagnosticsReport.js
+++ b/no.tiwas.booleantoolbox/lib/DiagnosticsReport.js
@@ -1,0 +1,197 @@
+"use strict";
+
+const DEFAULT_MAX_REPORT_LENGTH = 3600;
+const DEFAULT_MAX_EVENTS = 12;
+const GITHUB_NEW_ISSUE_URL = "https://github.com/Tiwas/SmartComponentsToolkit/issues/new";
+
+function isFiniteMetric(value) {
+    return value !== null
+        && value !== undefined
+        && value !== ""
+        && Number.isFinite(Number(value));
+}
+
+function redactDiagnosticText(value) {
+    return String(value ?? "")
+        .replace(/\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/gi, "<redacted-id>")
+        .replace(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi, "<redacted-email>")
+        .replace(/\b(?:\d{1,3}\.){3}\d{1,3}\b/g, "<redacted-ip>")
+        .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]+/gi, "$1<redacted-token>")
+        .replace(/\b(token|api[_-]?key|password|secret)\s*[:=]\s*([^\s,;]+)/gi, "$1=<redacted>")
+        .replace(/\b(?:[a-f0-9]{32,}|[A-Za-z0-9_-]{48,})\b/g, "<redacted-value>");
+}
+
+function formatBytes(value) {
+    if (!isFiniteMetric(value)) return "unavailable";
+    const bytes = Number(value);
+    if (bytes < 0) return "unavailable";
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatDuration(secondsValue) {
+    const totalSeconds = Math.max(0, Math.floor(Number(secondsValue) || 0));
+    const days = Math.floor(totalSeconds / 86400);
+    const hours = Math.floor((totalSeconds % 86400) / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+    const parts = [];
+
+    if (days) parts.push(`${days}d`);
+    if (hours || days) parts.push(`${hours}h`);
+    if (minutes || hours || days) parts.push(`${minutes}m`);
+    parts.push(`${seconds}s`);
+    return parts.join(" ");
+}
+
+function formatPercent(used, total) {
+    if (!isFiniteMetric(used) || !isFiniteMetric(total)) return "unavailable";
+    const usedValue = Number(used);
+    const totalValue = Number(total);
+    if (totalValue <= 0) return "unavailable";
+    return `${((usedValue / totalValue) * 100).toFixed(1)}%`;
+}
+
+function sanitizeEvent(event) {
+    if (!event || typeof event !== "object") return null;
+
+    const level = String(event.level || "INFO").toUpperCase();
+    const timestamp = Number.isNaN(new Date(event.timestamp).getTime())
+        ? "unknown time"
+        : new Date(event.timestamp).toISOString();
+    const category = redactDiagnosticText(event.category || "App").slice(0, 80);
+    const message = redactDiagnosticText(event.message || "").replace(/\s+/g, " ").trim().slice(0, 320);
+    const stack = redactDiagnosticText(event.stack || "").trim().slice(0, 900);
+
+    if (!message && !stack) return null;
+    return { level, timestamp, category, message, stack };
+}
+
+function buildDiagnosticsReport(data, options = {}) {
+    const maxReportLength = Math.max(1200, Number(options.maxReportLength) || DEFAULT_MAX_REPORT_LENGTH);
+    const maxEvents = Math.max(0, Number(options.maxEvents) || DEFAULT_MAX_EVENTS);
+    const deviceSummary = data.deviceSummary || {};
+    const registry = data.registry || {};
+    const clgGroups = Array.isArray(data.clgGroups) ? data.clgGroups : [];
+    const events = (Array.isArray(data.events) ? data.events : [])
+        .map(sanitizeEvent)
+        .filter(Boolean)
+        .slice(-maxEvents);
+    const memory = data.memory || {};
+    const resources = data.systemResources || {};
+    const systemMemoryUsed = isFiniteMetric(resources.memoryTotal)
+        && isFiniteMetric(resources.memoryFree)
+        ? Math.max(0, Number(resources.memoryTotal) - Number(resources.memoryFree))
+        : null;
+    const storageUsed = isFiniteMetric(resources.storageTotal)
+        && isFiniteMetric(resources.storageFree)
+        ? Math.max(0, Number(resources.storageTotal) - Number(resources.storageFree))
+        : null;
+    const loadAverage = Array.isArray(resources.loadAverage)
+        ? resources.loadAverage.slice(0, 3).map((value) => Number(value).toFixed(2)).join(" / ")
+        : "unavailable";
+
+    const lines = [
+        "# Smart (Components) Toolkit diagnostic report",
+        "",
+        `- Generated: ${data.generatedAt || new Date().toISOString()}`,
+        `- App version: ${data.appVersion || "unknown"}`,
+        `- Node.js: ${data.nodeVersion || "unknown"}`,
+        `- Current session started: ${data.startedAt || "unknown"}`,
+        `- Current session uptime: ${formatDuration(data.uptimeSeconds)}`,
+        `- Debug mode: ${data.debugMode === true ? "enabled" : "disabled"}`,
+        `- App state: ${resources.appState || "unavailable"}`,
+        `- Homey-reported crash count: ${resources.crashedCount ?? "unavailable"}`,
+        "",
+        "## Resource load",
+        "",
+        `- App process memory: RSS ${formatBytes(memory.rss)}, heap used ${formatBytes(memory.heapUsed)} of ${formatBytes(memory.heapTotal)}`,
+        `- Homey-reported app memory: ${formatBytes(resources.appMemory)}`,
+        `- Homey-reported app CPU metric: ${isFiniteMetric(resources.appCpu) ? Number(resources.appCpu).toFixed(6) : "unavailable"}`,
+        `- Homey system load average (1 / 5 / 15 min): ${loadAverage}${resources.cpuCores ? ` across ${resources.cpuCores} CPU core(s)` : ""}`,
+        `- Homey memory: ${formatBytes(systemMemoryUsed)} used of ${formatBytes(resources.memoryTotal)} (${formatBytes(resources.memoryFree)} free, ${formatPercent(systemMemoryUsed, resources.memoryTotal)} used)`,
+        `- Homey storage: ${formatBytes(storageUsed)} used of ${formatBytes(resources.storageTotal)} (${formatBytes(resources.storageFree)} free, ${formatPercent(storageUsed, resources.storageTotal)} used)`,
+        "",
+        "## Device load",
+        "",
+        `- App devices: ${deviceSummary.total || 0}`,
+        `- Devices with configuration alarm: ${deviceSummary.configAlarms || 0}`,
+        `- Homey registry snapshot: ${registry.currentCount || 0} current / ${registry.knownCount || 0} known / ${registry.missingCount || 0} deleted`,
+    ];
+
+    const drivers = Array.isArray(deviceSummary.drivers) ? deviceSummary.drivers : [];
+    for (const driver of drivers) {
+        lines.push(`- Driver ${redactDiagnosticText(driver.id).slice(0, 80)}: ${Number(driver.count) || 0}`);
+    }
+
+    lines.push("", "## Circadian Light Group load", "");
+    if (clgGroups.length === 0) {
+        lines.push("- No Circadian Light Group devices found.");
+    } else {
+        clgGroups.forEach((group, index) => {
+            lines.push(
+                `- Group ${index + 1}: ${group.enabledMembers || 0}/${group.totalMembers || 0} members enabled; ` +
+                `update ${group.updateIntervalSeconds || 120}s; transition ${group.transitionSeconds || 0}s; ` +
+                `watchers ${group.watchers || 0}; paused ${group.paused === true ? "yes" : "no"}`,
+            );
+        });
+    }
+
+    lines.push("", "## Recent warnings and errors", "");
+    if (events.length === 0) {
+        lines.push("- No captured warnings or errors.");
+    } else {
+        for (const event of events) {
+            lines.push(`- ${event.timestamp} [${event.level}] [${event.category}] ${event.message || "(no message)"}`);
+            if (event.stack) {
+                lines.push("```text", event.stack, "```");
+            }
+        }
+    }
+
+    if (resources.crashedMessage) {
+        lines.push("", "## Homey crash message", "", redactDiagnosticText(resources.crashedMessage).slice(0, 900));
+    }
+
+    const collectionErrors = Array.isArray(data.collectionErrors) ? data.collectionErrors : [];
+    if (collectionErrors.length > 0) {
+        lines.push("", "## Collection notes", "");
+        collectionErrors.forEach((message) => {
+            lines.push(`- ${redactDiagnosticText(message).slice(0, 240)}`);
+        });
+    }
+
+    lines.push(
+        "",
+        "## Privacy notice",
+        "",
+        "Device names and IDs are intentionally omitted from the structured data. Common identifiers and secrets are redacted from captured log lines, but please review this report before submitting it.",
+    );
+
+    const report = lines.join("\n");
+    if (report.length <= maxReportLength) return report;
+
+    const suffix = "\n\n_Report shortened to fit safely in a GitHub issue URL._";
+    return `${report.slice(0, maxReportLength - suffix.length).trimEnd()}${suffix}`;
+}
+
+function buildGitHubIssueUrl({ appVersion, report, summary }) {
+    const issueSummary = String(summary || "Diagnostic report")
+        .replace(/[\r\n]+/g, " ")
+        .trim()
+        .slice(0, 100) || "Diagnostic report";
+    const params = new URLSearchParams({
+        template: "01-bug-report.yml",
+        title: `[Bug]: ${issueSummary}`,
+        "app-version": String(appVersion || "unknown"),
+        logs: String(report || ""),
+    });
+
+    return `${GITHUB_NEW_ISSUE_URL}?${params.toString()}`;
+}
+
+module.exports = {
+    buildDiagnosticsReport,
+    buildGitHubIssueUrl,
+    redactDiagnosticText,
+    sanitizeEvent,
+};

--- a/no.tiwas.booleantoolbox/lib/DiagnosticsReport.js
+++ b/no.tiwas.booleantoolbox/lib/DiagnosticsReport.js
@@ -17,8 +17,9 @@ function redactDiagnosticText(value) {
         .replace(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi, "<redacted-email>")
         .replace(/\b(?:\d{1,3}\.){3}\d{1,3}\b/g, "<redacted-ip>")
         .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]+/gi, "$1<redacted-token>")
-        .replace(/\b(token|api[_-]?key|password|secret)\s*[:=]\s*([^\s,;]+)/gi, "$1=<redacted>")
-        .replace(/\b(?:[a-f0-9]{32,}|[A-Za-z0-9_-]{48,})\b/g, "<redacted-value>");
+        .replace(/(["']?(?:token|api[_-]?key|password|secret)["']?\s*[:=]\s*)(["'])(.*?)\2/gi, "$1$2<redacted>$2")
+        .replace(/(["']?(?:token|api[_-]?key|password|secret)["']?\s*[:=]\s*)([^,;\r\n}]+?)(?=\s+(?:Bearer\b|["']?(?:token|api[_-]?key|password|secret)["']?\s*[:=])|[,;\r\n}]|$)/gi, "$1<redacted>")
+        .replace(/\b(?:[a-f0-9]{20,}|[A-Za-z0-9_-]{32,})\b/g, "<redacted-value>");
 }
 
 function formatBytes(value) {
@@ -66,6 +67,19 @@ function sanitizeEvent(event) {
     return { level, timestamp, category, message, stack };
 }
 
+function shortenText(value, maxLength, marker) {
+    const text = String(value || "");
+    if (text.length <= maxLength) return text;
+    if (maxLength <= marker.length) return marker.slice(0, maxLength);
+    return `${text.slice(0, maxLength - marker.length).trimEnd()}${marker}`;
+}
+
+function formatEvent(event) {
+    const lines = [`- ${event.timestamp} [${event.level}] [${event.category}] ${event.message || "(no message)"}`];
+    if (event.stack) lines.push("```text", event.stack, "```");
+    return lines.join("\n");
+}
+
 function buildDiagnosticsReport(data, options = {}) {
     const maxReportLength = Math.max(1200, Number(options.maxReportLength) || DEFAULT_MAX_REPORT_LENGTH);
     const maxEvents = Math.max(0, Number(options.maxEvents) || DEFAULT_MAX_EVENTS);
@@ -90,7 +104,7 @@ function buildDiagnosticsReport(data, options = {}) {
         ? resources.loadAverage.slice(0, 3).map((value) => Number(value).toFixed(2)).join(" / ")
         : "unavailable";
 
-    const lines = [
+    const setupLines = [
         "# Smart (Components) Toolkit diagnostic report",
         "",
         `- Generated: ${data.generatedAt || new Date().toISOString()}`,
@@ -119,59 +133,84 @@ function buildDiagnosticsReport(data, options = {}) {
     ];
 
     const drivers = Array.isArray(deviceSummary.drivers) ? deviceSummary.drivers : [];
-    for (const driver of drivers) {
-        lines.push(`- Driver ${redactDiagnosticText(driver.id).slice(0, 80)}: ${Number(driver.count) || 0}`);
+    for (const driver of drivers.slice(0, 20)) {
+        setupLines.push(`- Driver ${redactDiagnosticText(driver.id).slice(0, 80)}: ${Number(driver.count) || 0}`);
+    }
+    if (drivers.length > 20) {
+        setupLines.push(`- ${drivers.length - 20} additional driver entries omitted.`);
     }
 
-    lines.push("", "## Circadian Light Group load", "");
+    setupLines.push("", "## Circadian Light Group load", "");
     if (clgGroups.length === 0) {
-        lines.push("- No Circadian Light Group devices found.");
+        setupLines.push("- No Circadian Light Group devices found.");
     } else {
-        clgGroups.forEach((group, index) => {
-            lines.push(
+        clgGroups.slice(0, 8).forEach((group, index) => {
+            setupLines.push(
                 `- Group ${index + 1}: ${group.enabledMembers || 0}/${group.totalMembers || 0} members enabled; ` +
                 `update ${group.updateIntervalSeconds || 120}s; transition ${group.transitionSeconds || 0}s; ` +
                 `watchers ${group.watchers || 0}; paused ${group.paused === true ? "yes" : "no"}`,
             );
         });
-    }
-
-    lines.push("", "## Recent warnings and errors", "");
-    if (events.length === 0) {
-        lines.push("- No captured warnings or errors.");
-    } else {
-        for (const event of events) {
-            lines.push(`- ${event.timestamp} [${event.level}] [${event.category}] ${event.message || "(no message)"}`);
-            if (event.stack) {
-                lines.push("```text", event.stack, "```");
-            }
+        if (clgGroups.length > 8) {
+            setupLines.push(`- ${clgGroups.length - 8} additional groups omitted.`);
         }
     }
 
     if (resources.crashedMessage) {
-        lines.push("", "## Homey crash message", "", redactDiagnosticText(resources.crashedMessage).slice(0, 900));
+        setupLines.push("", "## Homey crash message", "", redactDiagnosticText(resources.crashedMessage).slice(0, 600));
     }
 
     const collectionErrors = Array.isArray(data.collectionErrors) ? data.collectionErrors : [];
     if (collectionErrors.length > 0) {
-        lines.push("", "## Collection notes", "");
-        collectionErrors.forEach((message) => {
-            lines.push(`- ${redactDiagnosticText(message).slice(0, 240)}`);
+        setupLines.push("", "## Collection notes", "");
+        collectionErrors.slice(0, 5).forEach((message) => {
+            setupLines.push(`- ${redactDiagnosticText(message).slice(0, 240)}`);
         });
+        if (collectionErrors.length > 5) setupLines.push(`- ${collectionErrors.length - 5} additional notes omitted.`);
     }
 
-    lines.push(
-        "",
+    const privacyText = [
         "## Privacy notice",
         "",
         "Device names and IDs are intentionally omitted from the structured data. Common identifiers and secrets are redacted from captured log lines, but please review this report before submitting it.",
+    ].join("\n");
+    const eventHeading = "## Recent warnings and errors";
+    let eventText = "- No captured warnings or errors.";
+
+    if (events.length > 0) {
+        const eventBudget = Math.max(320, Math.min(
+            Math.floor(maxReportLength * 0.45),
+            maxReportLength - privacyText.length - eventHeading.length - 450,
+        ));
+        const formattedEvents = events.map(formatEvent);
+        const selected = [shortenText(
+            formattedEvents.at(-1),
+            eventBudget,
+            "\n_Event details shortened; the newest message is preserved._",
+        )];
+
+        for (let index = formattedEvents.length - 2; index >= 0; index -= 1) {
+            const candidate = [formattedEvents[index], ...selected].join("\n");
+            if (candidate.length > eventBudget) break;
+            selected.unshift(formattedEvents[index]);
+        }
+
+        eventText = selected.join("\n");
+        const omittedCount = formattedEvents.length - selected.length;
+        const omissionNote = `_${omittedCount} older event(s) omitted to preserve the newest diagnostics._`;
+        if (omittedCount > 0 && `${omissionNote}\n${eventText}`.length <= eventBudget) {
+            eventText = `${omissionNote}\n${eventText}`;
+        }
+    }
+
+    const tailText = `${eventHeading}\n\n${eventText}\n\n${privacyText}`;
+    const setupBudget = Math.max(0, maxReportLength - tailText.length - 2);
+    const setupText = shortenText(
+        setupLines.join("\n"),
+        setupBudget,
+        "\n\n_Setup details shortened to preserve the newest diagnostics._",
     );
-
-    const report = lines.join("\n");
-    if (report.length <= maxReportLength) return report;
-
-    const suffix = "\n\n_Report shortened to fit safely in a GitHub issue URL._";
-    return `${report.slice(0, maxReportLength - suffix.length).trimEnd()}${suffix}`;
+    return `${setupText}\n\n${tailText}`.slice(0, maxReportLength);
 }
 
 function buildGitHubIssueUrl({ appVersion, report, summary }) {
@@ -179,11 +218,32 @@ function buildGitHubIssueUrl({ appVersion, report, summary }) {
         .replace(/[\r\n]+/g, " ")
         .trim()
         .slice(0, 100) || "Diagnostic report";
+    const body = [
+        "## Problem summary",
+        "",
+        issueSummary,
+        "",
+        "## Steps to reproduce",
+        "",
+        "<!-- Please describe what happens before the problem occurs. -->",
+        "",
+        "## Expected behavior",
+        "",
+        "<!-- What did you expect to happen? -->",
+        "",
+        "## Actual behavior",
+        "",
+        "<!-- What happened instead? Include the approximate local time. -->",
+        "",
+        `## App version\n\n${String(appVersion || "unknown")}`,
+        "",
+        "## Diagnostic report",
+        "",
+        String(report || "No diagnostic report was generated."),
+    ].join("\n");
     const params = new URLSearchParams({
-        template: "01-bug-report.yml",
         title: `[Bug]: ${issueSummary}`,
-        "app-version": String(appVersion || "unknown"),
-        logs: String(report || ""),
+        body,
     });
 
     return `${GITHUB_NEW_ISSUE_URL}?${params.toString()}`;

--- a/no.tiwas.booleantoolbox/lib/Logger.js
+++ b/no.tiwas.booleantoolbox/lib/Logger.js
@@ -257,13 +257,19 @@ class Logger {
     const app = this.homey && this.homey.app;
     if (!app || typeof app.recordDiagnosticEvent !== "function") return;
 
+    const stack = error instanceof Error && typeof error.stack === "string"
+      ? error.stack.split(/\r?\n/).slice(1).join("\n")
+      : "";
+
     try {
       app.recordDiagnosticEvent({
         timestamp: new Date().toISOString(),
         level,
         category: this.category,
-        message,
-        stack: error instanceof Error ? error.stack : "",
+        // Formatted log messages can contain user-defined device, room, waiter,
+        // or formula labels. Keep the persisted diagnostic event label-free.
+        message: level === "WARN" ? "Warning recorded." : "Error recorded.",
+        stack,
       });
     } catch (recordingError) {
       console.error("Logger diagnostic capture failed:", recordingError);

--- a/no.tiwas.booleantoolbox/lib/Logger.js
+++ b/no.tiwas.booleantoolbox/lib/Logger.js
@@ -399,7 +399,7 @@ class Logger {
    * (logging stack traces). Uses Homey's app.error() for output.
    *
    * @private
-   * @param {string} keyOrMessage - Error message or locale key
+   * @param {string|Error} keyOrMessage - Error message, locale key, or Error object
    * @param {Error|Object} [error] - Error object (logs stack) or data object
    *
    * Called by:
@@ -421,24 +421,28 @@ class Logger {
 
     const prefix = this._getPrefix(Logger.SYMBOLS.ERROR);
 
+    const errorObject = keyOrMessage instanceof Error
+      ? keyOrMessage
+      : error instanceof Error ? error : null;
+    const message = keyOrMessage instanceof Error ? keyOrMessage.message : keyOrMessage;
     // Data-objektet kan være gjemt i 'error' hvis det ikke er en ekte Error
-    let data = error instanceof Error ? null : error;
-    const formattedMessage = this._formatMessage(keyOrMessage, data);
-    this._recordDiagnosticEvent("ERROR", formattedMessage, error);
+    const data = errorObject ? null : error;
+    const formattedMessage = this._formatMessage(message, data);
+    this._recordDiagnosticEvent("ERROR", formattedMessage, errorObject);
 
     try {
       // --- FIKS: Flyttet levelString FØRST ---
       this.homey.app.error(levelString, prefix, formattedMessage);
-      if (error instanceof Error) {
-        this.homey.app.error(error); // Logg stack trace hvis det er en Error
+      if (errorObject) {
+        this.homey.app.error(errorObject); // Logg stack trace hvis det er en Error
       } else if (data) {
         // Hvis 'error' bare var data, er den allerede i formattedMessage
       }
     } catch (err) {
       console.error("Logger internal error (error):", err);
       console.error(levelString, prefix, formattedMessage);
-      if (error) {
-        console.error(error);
+      if (errorObject || error) {
+        console.error(errorObject || error);
       }
     }
   }

--- a/no.tiwas.booleantoolbox/lib/Logger.js
+++ b/no.tiwas.booleantoolbox/lib/Logger.js
@@ -252,6 +252,24 @@ class Logger {
     return `${symbol} [${this.category}]`;
   }
 
+  _recordDiagnosticEvent(level, message, error) {
+    if (level !== "WARN" && level !== "ERROR") return;
+    const app = this.homey && this.homey.app;
+    if (!app || typeof app.recordDiagnosticEvent !== "function") return;
+
+    try {
+      app.recordDiagnosticEvent({
+        timestamp: new Date().toISOString(),
+        level,
+        category: this.category,
+        message,
+        stack: error instanceof Error ? error.stack : "",
+      });
+    } catch (recordingError) {
+      console.error("Logger diagnostic capture failed:", recordingError);
+    }
+  }
+
   /**
    * Formats a message with optional localization and variable substitution.
    *
@@ -364,6 +382,7 @@ class Logger {
     const levelString = `[${level.padEnd(5)}]`;
     const prefix = this._getPrefix(symbol);
     const formattedMessage = this._formatMessage(keyOrMessage, data);
+    this._recordDiagnosticEvent(level, formattedMessage);
 
     try {
       this.homey.app.log(levelString, prefix, formattedMessage);
@@ -405,6 +424,7 @@ class Logger {
     // Data-objektet kan være gjemt i 'error' hvis det ikke er en ekte Error
     let data = error instanceof Error ? null : error;
     const formattedMessage = this._formatMessage(keyOrMessage, data);
+    this._recordDiagnosticEvent("ERROR", formattedMessage, error);
 
     try {
       // --- FIKS: Flyttet levelString FØRST ---

--- a/no.tiwas.booleantoolbox/locales/en.json
+++ b/no.tiwas.booleantoolbox/locales/en.json
@@ -688,6 +688,20 @@
       "help": "Enables detailed logging for troubleshooting. Not recommended for daily use as it generates a lot of logs.",
       "legend": "Debug"
     },
+    "diagnostics": {
+      "copied": "Diagnostic report copied.",
+      "copy": "Copy report",
+      "failed": "Could not generate the diagnostic report.",
+      "generate": "Generate report",
+      "generated": "Report generated locally. Review it before opening GitHub.",
+      "help": "Generate a local report with app version, uptime, CPU, memory, storage, anonymous device counts, Circadian Light Group load, and recent warnings or errors. Common identifiers and secrets are redacted, but review the report before submitting it.",
+      "legend": "Diagnostics and support",
+      "not_generated": "No report generated. Nothing is uploaded automatically.",
+      "open_github": "Open prefilled GitHub issue",
+      "report_label": "Report preview",
+      "summary_label": "Short problem summary",
+      "summary_placeholder": "For example: Circadian group resets every 30 seconds"
+    },
     "device_registry": {
       "current": "Current",
       "deleted": "Deleted",

--- a/no.tiwas.booleantoolbox/locales/no.json
+++ b/no.tiwas.booleantoolbox/locales/no.json
@@ -689,6 +689,20 @@
       "help": "Aktiverer detaljert logging for feilsøking. Anbefales ikke for daglig bruk da det genererer mye logg.",
       "legend": "Feilsøking"
     },
+    "diagnostics": {
+      "copied": "Diagnoserapporten er kopiert.",
+      "copy": "Kopier rapport",
+      "failed": "Kunne ikke generere diagnoserapporten.",
+      "generate": "Generer rapport",
+      "generated": "Rapporten er generert lokalt. Kontroller den før du åpner GitHub.",
+      "help": "Generer en lokal rapport med appversjon, oppetid, CPU-, minne- og lagringsbelastning, anonymiserte enhetstall, belastning for Circadian Light Group og nylige advarsler eller feil. Vanlige identifikatorer og hemmeligheter maskeres, men kontroller rapporten før innsending.",
+      "legend": "Diagnostikk og brukerstøtte",
+      "not_generated": "Ingen rapport er generert. Ingenting lastes opp automatisk.",
+      "open_github": "Åpne ferdig utfylt GitHub-sak",
+      "report_label": "Forhåndsvisning av rapport",
+      "summary_label": "Kort beskrivelse av problemet",
+      "summary_placeholder": "For eksempel: Circadian-gruppen nullstilles hvert 30. sekund"
+    },
     "device_registry": {
       "current": "Nåværende",
       "deleted": "Slettet",

--- a/no.tiwas.booleantoolbox/package-lock.json
+++ b/no.tiwas.booleantoolbox/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "no.tiwas.booleantoolbox",
-  "version": "1.10.25",
+  "version": "1.10.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "no.tiwas.booleantoolbox",
-      "version": "1.10.25",
+      "version": "1.10.28",
       "license": "ISC",
       "dependencies": {
         "homey-api": "3.17.0",

--- a/no.tiwas.booleantoolbox/package.json
+++ b/no.tiwas.booleantoolbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "no.tiwas.booleantoolbox",
-  "version": "1.10.25",
+  "version": "1.10.28",
   "main": "app.js",
   "dependencies": {
     "homey-api": "3.17.0",

--- a/no.tiwas.booleantoolbox/settings/index.html
+++ b/no.tiwas.booleantoolbox/settings/index.html
@@ -485,8 +485,9 @@
         openGitHubIssueButton.addEventListener('click', async function() {
           openGitHubIssueButton.disabled = true;
           try {
-            const payload = await generateDiagnostics();
-            Homey.openURL(payload.issueUrl);
+            if (diagnosticsPayload && diagnosticsPayload.issueUrl) {
+              Homey.openURL(diagnosticsPayload.issueUrl);
+            }
           } catch (err) {
             Homey.alert(err.message || String(err));
           } finally {

--- a/no.tiwas.booleantoolbox/settings/index.html
+++ b/no.tiwas.booleantoolbox/settings/index.html
@@ -57,6 +57,13 @@
       .sct-muted {
         opacity: 0.7;
       }
+
+      .sct-diagnostic-report {
+        min-height: 280px;
+        font-family: monospace;
+        font-size: 12px;
+        white-space: pre;
+      }
     </style>
   </head>
   <body>
@@ -134,6 +141,44 @@
       </div>
     </fieldset>
 
+    <fieldset class="homey-form-fieldset">
+      <legend class="homey-form-legend" data-i18n="settings.diagnostics.legend">Diagnostics and support</legend>
+
+      <div class="homey-form-group">
+        <label class="homey-form-label" for="diagnostics_summary" data-i18n="settings.diagnostics.summary_label">
+          Short problem summary
+        </label>
+        <div class="homey-form-input-group">
+          <input class="homey-form-input" type="text" maxlength="100" id="diagnostics_summary" data-i18n-placeholder="settings.diagnostics.summary_placeholder" placeholder="For example: Circadian group resets every 30 seconds" />
+        </div>
+      </div>
+
+      <div class="homey-form-group">
+        <p class="homey-form-help" data-i18n="settings.diagnostics.help">
+          Generate a local report with app version, uptime, CPU, memory, storage, anonymous device counts, Circadian Light Group load, and recent warnings or errors. Common identifiers and secrets are redacted, but review the report before submitting it.
+        </p>
+        <div class="sct-actions">
+          <button class="homey-button-secondary sct-button" id="generate_diagnostics_button" type="button" data-i18n="settings.diagnostics.generate">
+            Generate report
+          </button>
+          <button class="homey-button-secondary sct-button" id="copy_diagnostics_button" type="button" disabled data-i18n="settings.diagnostics.copy">
+            Copy report
+          </button>
+          <button class="homey-button-primary sct-button" id="open_github_issue_button" type="button" disabled data-i18n="settings.diagnostics.open_github">
+            Open prefilled GitHub issue
+          </button>
+        </div>
+        <p class="homey-form-help sct-status" id="diagnostics_status" data-i18n="settings.diagnostics.not_generated">
+          No report generated. Nothing is uploaded automatically.
+        </p>
+      </div>
+
+      <div class="homey-form-group">
+        <label class="homey-form-label" for="diagnostics_report" data-i18n="settings.diagnostics.report_label">Report preview</label>
+        <textarea class="homey-form-textarea sct-diagnostic-report" id="diagnostics_report" rows="14" readonly></textarea>
+      </div>
+    </fieldset>
+
     <button class="homey-button-primary-full" id="save_button" data-i18n="settings.save">Save</button>
 
     <script type="text/javascript">
@@ -152,8 +197,15 @@
         const resultsEl = document.getElementById('device_registry_results');
         const refreshButton = document.getElementById('refresh_registry_button');
         const purgeButton = document.getElementById('purge_registry_button');
+        const diagnosticsSummaryInput = document.getElementById('diagnostics_summary');
+        const diagnosticsReportInput = document.getElementById('diagnostics_report');
+        const diagnosticsStatusEl = document.getElementById('diagnostics_status');
+        const generateDiagnosticsButton = document.getElementById('generate_diagnostics_button');
+        const copyDiagnosticsButton = document.getElementById('copy_diagnostics_button');
+        const openGitHubIssueButton = document.getElementById('open_github_issue_button');
 
         let registry = null;
+        let diagnosticsPayload = null;
 
         Homey.ready();
 
@@ -182,6 +234,43 @@
               resolve();
             });
           });
+        }
+
+        function callApi(method, path, body) {
+          return new Promise((resolve, reject) => {
+            Homey.api(method, path, body, (err, result) => {
+              if (err) return reject(err);
+              resolve(result);
+            });
+          });
+        }
+
+        async function generateDiagnostics() {
+          diagnosticsPayload = await callApi('POST', '/diagnostics', {
+            summary: diagnosticsSummaryInput.value,
+          });
+          diagnosticsReportInput.value = diagnosticsPayload.report || '';
+          copyDiagnosticsButton.disabled = !diagnosticsReportInput.value;
+          openGitHubIssueButton.disabled = !diagnosticsPayload.issueUrl;
+          diagnosticsStatusEl.textContent = text(
+            'settings.diagnostics.generated',
+            'Report generated locally. Review it before opening GitHub.'
+          );
+          return diagnosticsPayload;
+        }
+
+        async function copyDiagnosticsReport() {
+          const report = diagnosticsReportInput.value;
+          if (!report) return;
+
+          if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+            await navigator.clipboard.writeText(report);
+          } else {
+            diagnosticsReportInput.focus();
+            diagnosticsReportInput.select();
+            document.execCommand('copy');
+          }
+          Homey.alert(text('settings.diagnostics.copied', 'Diagnostic report copied.'), 'info');
         }
 
         function escapeHtml(value) {
@@ -364,6 +453,44 @@
             Homey.alert(err.message || String(err));
           } finally {
             purgeButton.disabled = false;
+          }
+        });
+
+        generateDiagnosticsButton.addEventListener('click', async function() {
+          generateDiagnosticsButton.disabled = true;
+          try {
+            await generateDiagnostics();
+          } catch (err) {
+            diagnosticsStatusEl.textContent = text(
+              'settings.diagnostics.failed',
+              'Could not generate the diagnostic report.'
+            );
+            Homey.alert(err.message || String(err));
+          } finally {
+            generateDiagnosticsButton.disabled = false;
+          }
+        });
+
+        copyDiagnosticsButton.addEventListener('click', async function() {
+          copyDiagnosticsButton.disabled = true;
+          try {
+            await copyDiagnosticsReport();
+          } catch (err) {
+            Homey.alert(err.message || String(err));
+          } finally {
+            copyDiagnosticsButton.disabled = !diagnosticsReportInput.value;
+          }
+        });
+
+        openGitHubIssueButton.addEventListener('click', async function() {
+          openGitHubIssueButton.disabled = true;
+          try {
+            const payload = await generateDiagnostics();
+            Homey.openURL(payload.issueUrl);
+          } catch (err) {
+            Homey.alert(err.message || String(err));
+          } finally {
+            openGitHubIssueButton.disabled = !(diagnosticsPayload && diagnosticsPayload.issueUrl);
           }
         });
 


### PR DESCRIPTION
## Summary
- add a privacy-conscious diagnostic report in Homey App Settings
- prefill the existing GitHub bug form without embedding GitHub credentials
- include persisted warning/error stacks, anonymous device and Circadian Light Group load, and available CPU, memory, and storage metrics
- prepare Homey test version 1.10.28 and update release/community documentation

## Verification
- `npm test -- --runInBand` (18 suites, 206 tests)
- `npm run test:package` (publish validation; 766 files, 7.51 MB; 17 assets verified)
- `homey app run --remote` smoke test on the configured Homey Pro