### PR TITLE
Fix diagnostics when resource metrics are unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to Smart (Components) Toolkit for Homey will be documented i
 
 ---
 
+## [1.10.29] - September 2026 (Test channel)
+
+### Fixed
+- Diagnostic reports no longer fail when Homey cannot expose process memory or another resource metric. Unavailable CPU, memory, and storage values are now reported as unavailable while the rest of the report is preserved.
+
 ## [1.10.28] - September 2026 (Test channel)
 
 ### Added

--- a/HOMEY_COMMUNITY_LISTING.md
+++ b/HOMEY_COMMUNITY_LISTING.md
@@ -1,11 +1,11 @@
 URL: https://community.homey.app/t/app-smart-components-toolkit-was-boolean-toolbox-create-advanced-logic-with-simple-formulas-v1-10-16-store-v1-10-27-test-logic-device-reliability/143906
 
-Title: [APP] Smart (Components) Toolkit (was: Boolean Toolbox) - Create advanced logic with simple formulas [v1.10.16 store / v1.10.28 test - GitHub diagnostics]
+Title: [APP] Smart (Components) Toolkit (was: Boolean Toolbox) - Create advanced logic with simple formulas [v1.10.16 store / v1.10.29 test - Diagnostics fix]
 
 Content:
 ![xlarge|690x483](upload://iSxhJPUltgcgPQ7gy4z5iisCv5F.jpeg)
 
-# Smart (Components) Toolkit — store v1.10.16 / test v1.10.28
+# Smart (Components) Toolkit — store v1.10.16 / test v1.10.29
 
 > **📚 Full Documentation:** https://tiwas.github.io/SmartComponentsToolkit/
 
@@ -16,6 +16,11 @@ Replace complex flow networks with powerful logic devices controlled by dynamic 
 ---
 
 ## What's new
+
+### v1.10.29 (test channel)
+
+- **Diagnostic report generation fixed:** Homey models that cannot provide process-memory or other resource metrics can now generate a report successfully.
+- **Graceful resource fallback:** unavailable CPU, memory, or storage values are shown as `unavailable`; all other diagnostics remain in the report.
 
 ### v1.10.28 (test channel)
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 Advanced logic and state management for your Homey automations. Create smart devices that react to multiple inputs with customizable formulas, and manage device states with powerful capture/restore functionality.
 
 [![Stable](https://img.shields.io/badge/stable-1.10.9-blue.svg)](https://homey.app/en-no/app/no.tiwas.booleantoolbox/)
-[![Test](https://img.shields.io/badge/test-1.10.28-orange.svg)](https://homey.app/a/no.tiwas.booleantoolbox/test/)
+[![Test](https://img.shields.io/badge/test-1.10.29-orange.svg)](https://homey.app/a/no.tiwas.booleantoolbox/test/)
 [![Homey](https://img.shields.io/badge/Homey-5.0+-green.svg)](https://homey.app)
 
-> **v1.10.28 test** — adds privacy-conscious diagnostic reports that can be reviewed and submitted through a prefilled GitHub issue.
+> **v1.10.29 test** — fixes diagnostic report generation when Homey does not expose one or more resource metrics.
 
 ---
 
@@ -138,7 +138,7 @@ THEN: Pop state (restore previous)
 
 ---
 
-### Circadian Light Group *(stable v1.10.16 / test v1.10.28)*
+### Circadian Light Group *(stable v1.10.16 / test v1.10.29)*
 
 Virtual light device that adjusts brightness and color temperature for a group of real lights based on time, sun position or ambient lux.
 

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -9,6 +9,7 @@
 ### Implemented
 - Made Node.js process-memory and operating-system resource probes best effort so unavailable platform metrics cannot abort report generation.
 - Wrapped Homey API resource calls so both synchronous exceptions and rejected promises degrade to unavailable values.
+- Ensured missing or incomplete load averages are rendered explicitly as unavailable.
 - Added regression coverage for the reported process-memory failure and unavailable Homey resource endpoints.
 - Prepared the v1.10.29 patch-release metadata and Community post source.
 

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -1,5 +1,21 @@
 # Worklog
 
+## 2026-09-07 — Diagnostic resource fallback v1.10.29
+
+### Requested
+- Fix the App Settings diagnostic report after a user received `ENOENT: no such file or directory, uv_resident_set_memory`.
+- Publish the fix as a new Homey draft release.
+
+### Implemented
+- Made Node.js process-memory and operating-system resource probes best effort so unavailable platform metrics cannot abort report generation.
+- Wrapped Homey API resource calls so both synchronous exceptions and rejected promises degrade to unavailable values.
+- Added regression coverage for the reported process-memory failure and unavailable Homey resource endpoints.
+- Prepared the v1.10.29 patch-release metadata and Community post source.
+
+### Verification
+- `npm test -- --runInBand`: 19 suites and 210 tests passed.
+- `npm run test:package`: publish-level validation passed; bundle contains 766 files (7.51 MB) and all 17 manifest assets were verified.
+
 ## 2026-09-06 — GitHub diagnostic reports and test release v1.10.28
 
 ### Requested

--- a/no.tiwas.booleantoolbox/.homeychangelog.json
+++ b/no.tiwas.booleantoolbox/.homeychangelog.json
@@ -132,5 +132,11 @@
   "1.10.27": {
     "en": "Serialize Logic Device formula evaluations to prevent stale results and reduce routine Logic Unit logging.",
     "no": "Serialiserer Logic Device-formelutregninger for å hindre foreldede resultater og reduserer vanlig Logic Unit-logging."
+  },
+  "1.10.28": {
+    "en": "Added privacy-conscious diagnostics in App Settings with prefilled GitHub issues, recent anonymous warnings and stack frames, device and Circadian Light Group load, plus available CPU, memory, and storage metrics."
+  },
+  "1.10.29": {
+    "en": "Fixed diagnostic report generation on Homey systems where process memory or other resource metrics are unavailable."
   }
 }

--- a/no.tiwas.booleantoolbox/.homeycompose/app.json
+++ b/no.tiwas.booleantoolbox/.homeycompose/app.json
@@ -1,7 +1,7 @@
 {
   "id": "no.tiwas.booleantoolbox",
   "support": "https://community.homey.app/t/app-boolean-toolbox-create-advanced-logic-with-simple-formulas/143906",
-  "version": "1.10.28",
+  "version": "1.10.29",
   "compatibility": ">=5.0.0",
   "sdk": 3,
   "permissions": [

--- a/no.tiwas.booleantoolbox/AppDiagnostics.test.js
+++ b/no.tiwas.booleantoolbox/AppDiagnostics.test.js
@@ -2,7 +2,7 @@
 
 jest.mock("homey", () => ({
     App: class {},
-    manifest: { version: "1.10.28" },
+    manifest: { version: "1.10.29" },
 }), { virtual: true });
 
 jest.mock("./lib/Logger", () => class MockLogger {});
@@ -40,7 +40,7 @@ describe("BooleanToolboxApp diagnostics", () => {
             memberOnoffWatchers: new Map([["secret-light-id", {}]]),
         };
         app.homey = {
-            manifest: { version: "1.10.28" },
+            manifest: { version: "1.10.29" },
             settings,
             drivers: {
                 getDrivers: jest.fn(() => ({
@@ -84,7 +84,7 @@ describe("BooleanToolboxApp diagnostics", () => {
         const payload = await app.getDiagnosticsPayload("Group resets");
         const issueUrl = new URL(payload.issueUrl);
 
-        expect(payload.appVersion).toBe("1.10.28");
+        expect(payload.appVersion).toBe("1.10.29");
         expect(payload.report).toContain("App devices: 1");
         expect(payload.report).toContain("1/2 members enabled");
         expect(payload.report).toContain("update 30s");
@@ -94,7 +94,7 @@ describe("BooleanToolboxApp diagnostics", () => {
         expect(payload.report).not.toContain("Private bedroom");
         expect(payload.report).not.toContain("secret-light-id");
         expect(issueUrl.searchParams.get("body")).toContain(payload.report);
-        expect(issueUrl.searchParams.get("body")).toContain("## App version\n\n1.10.28");
+        expect(issueUrl.searchParams.get("body")).toContain("## App version\n\n1.10.29");
         expect(issueUrl.searchParams.get("title")).toBe("[Bug]: Group resets");
     });
 
@@ -145,5 +145,47 @@ describe("BooleanToolboxApp diagnostics", () => {
             updateIntervalSeconds: 120,
         })]);
         expect(result.collectionErrors).toContain("A Circadian Light Group has a non-object configuration.");
+    });
+
+    test("generates a report when process memory and Homey resource probes are unavailable", async () => {
+        const memoryError = Object.assign(
+            new Error("ENOENT: no such file or directory, uv_resident_set_memory"),
+            { code: "ENOENT" },
+        );
+        const memorySpy = jest.spyOn(process, "memoryUsage").mockImplementation(() => {
+            throw memoryError;
+        });
+        const app = new BooleanToolboxApp();
+        app.homey = {
+            manifest: { version: "1.10.29" },
+            settings: createSettings({}),
+            drivers: { getDrivers: jest.fn(() => ({})) },
+        };
+        app.api = {
+            system: {
+                getInfo: jest.fn(() => { throw new Error("info unavailable"); }),
+                getMemoryInfo: jest.fn(() => { throw new Error("memory unavailable"); }),
+                getStorageInfo: jest.fn(() => { throw new Error("storage unavailable"); }),
+            },
+            apps: {
+                getApp: jest.fn(() => { throw new Error("app metrics unavailable"); }),
+            },
+        };
+        app.startedAt = new Date();
+        app.diagnosticEvents = [];
+
+        try {
+            const payload = await app.getDiagnosticsPayload("Resource probe failure");
+
+            expect(payload.report).toContain("App version: 1.10.29");
+            expect(payload.report).toContain(
+                "App process memory: RSS unavailable, heap used unavailable of unavailable",
+            );
+            expect(payload.report).toContain("Homey-reported app memory: unavailable");
+            expect(payload.report).toContain("Homey storage: unavailable used of unavailable");
+            expect(new URL(payload.issueUrl).searchParams.get("body")).toContain(payload.report);
+        } finally {
+            memorySpy.mockRestore();
+        }
     });
 });

--- a/no.tiwas.booleantoolbox/AppDiagnostics.test.js
+++ b/no.tiwas.booleantoolbox/AppDiagnostics.test.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const os = require("node:os");
+
 jest.mock("homey", () => ({
     App: class {},
     manifest: { version: "1.10.29" },
@@ -155,6 +157,9 @@ describe("BooleanToolboxApp diagnostics", () => {
         const memorySpy = jest.spyOn(process, "memoryUsage").mockImplementation(() => {
             throw memoryError;
         });
+        const loadAverageSpy = jest.spyOn(os, "loadavg").mockImplementation(() => {
+            throw new Error("load average unavailable");
+        });
         const app = new BooleanToolboxApp();
         app.homey = {
             manifest: { version: "1.10.29" },
@@ -182,10 +187,14 @@ describe("BooleanToolboxApp diagnostics", () => {
                 "App process memory: RSS unavailable, heap used unavailable of unavailable",
             );
             expect(payload.report).toContain("Homey-reported app memory: unavailable");
+            expect(payload.report).toContain(
+                "Homey system load average (1 / 5 / 15 min): unavailable",
+            );
             expect(payload.report).toContain("Homey storage: unavailable used of unavailable");
             expect(new URL(payload.issueUrl).searchParams.get("body")).toContain(payload.report);
         } finally {
             memorySpy.mockRestore();
+            loadAverageSpy.mockRestore();
         }
     });
 });

--- a/no.tiwas.booleantoolbox/app.js
+++ b/no.tiwas.booleantoolbox/app.js
@@ -36,6 +36,19 @@ function isFiniteDiagnosticMetric(value) {
         && Number.isFinite(Number(value));
 }
 
+function getDiagnosticValue(getter, fallback = null) {
+    try {
+        return getter();
+    } catch (error) {
+        return fallback;
+    }
+}
+
+function getProcessMemoryDiagnostics() {
+    const memory = getDiagnosticValue(() => process.memoryUsage(), null);
+    return memory && typeof memory === "object" ? memory : {};
+}
+
 /**
  * Helper function for evaluate_expression action card.
  *
@@ -392,11 +405,13 @@ module.exports = class BooleanToolboxApp extends Homey.App {
     }
 
     async collectResourceDiagnostics() {
+        const cpuInfo = getDiagnosticValue(() => os.cpus(), []);
+        const loadAverage = getDiagnosticValue(() => os.loadavg(), []);
         const systemResources = {
-            cpuCores: os.cpus().length || null,
-            loadAverage: os.loadavg(),
-            memoryTotal: os.totalmem(),
-            memoryFree: os.freemem(),
+            cpuCores: Array.isArray(cpuInfo) ? cpuInfo.length || null : null,
+            loadAverage: Array.isArray(loadAverage) ? loadAverage : [],
+            memoryTotal: getDiagnosticValue(() => os.totalmem(), null),
+            memoryFree: getDiagnosticValue(() => os.freemem(), null),
             storageTotal: null,
             storageFree: null,
             appCpu: null,
@@ -414,12 +429,20 @@ module.exports = class BooleanToolboxApp extends Homey.App {
         }
 
         const calls = [
-            typeof api.system?.getInfo === "function" ? api.system.getInfo() : Promise.resolve(null),
-            typeof api.system?.getMemoryInfo === "function" ? api.system.getMemoryInfo() : Promise.resolve(null),
-            typeof api.system?.getStorageInfo === "function" ? api.system.getStorageInfo() : Promise.resolve(null),
-            typeof api.apps?.getApp === "function"
-                ? api.apps.getApp({ id: "no.tiwas.booleantoolbox" })
-                : Promise.resolve(null),
+            Promise.resolve().then(() => (
+                typeof api.system?.getInfo === "function" ? api.system.getInfo() : null
+            )),
+            Promise.resolve().then(() => (
+                typeof api.system?.getMemoryInfo === "function" ? api.system.getMemoryInfo() : null
+            )),
+            Promise.resolve().then(() => (
+                typeof api.system?.getStorageInfo === "function" ? api.system.getStorageInfo() : null
+            )),
+            Promise.resolve().then(() => (
+                typeof api.apps?.getApp === "function"
+                    ? api.apps.getApp({ id: "no.tiwas.booleantoolbox" })
+                    : null
+            )),
         ];
         const [infoResult, memoryResult, storageResult, appResult] = await Promise.allSettled(calls);
 
@@ -481,7 +504,7 @@ module.exports = class BooleanToolboxApp extends Homey.App {
             uptimeSeconds: Math.max(0, (generatedAt.getTime() - startedAt.getTime()) / 1000),
             nodeVersion: process.version,
             debugMode: this.homey.settings.get("debug_mode") === true,
-            memory: process.memoryUsage(),
+            memory: getProcessMemoryDiagnostics(),
             systemResources,
             deviceSummary: deviceDiagnostics.summary,
             clgGroups: deviceDiagnostics.clgGroups,

--- a/no.tiwas.booleantoolbox/lib/DiagnosticsReport.js
+++ b/no.tiwas.booleantoolbox/lib/DiagnosticsReport.js
@@ -100,8 +100,11 @@ function buildDiagnosticsReport(data, options = {}) {
         && isFiniteMetric(resources.storageFree)
         ? Math.max(0, Number(resources.storageTotal) - Number(resources.storageFree))
         : null;
-    const loadAverage = Array.isArray(resources.loadAverage)
-        ? resources.loadAverage.slice(0, 3).map((value) => Number(value).toFixed(2)).join(" / ")
+    const loadAverageValues = Array.isArray(resources.loadAverage)
+        ? resources.loadAverage.slice(0, 3)
+        : [];
+    const loadAverage = loadAverageValues.length === 3 && loadAverageValues.every(isFiniteMetric)
+        ? loadAverageValues.map((value) => Number(value).toFixed(2)).join(" / ")
         : "unavailable";
 
     const setupLines = [

--- a/no.tiwas.booleantoolbox/package-lock.json
+++ b/no.tiwas.booleantoolbox/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "no.tiwas.booleantoolbox",
-  "version": "1.10.28",
+  "version": "1.10.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "no.tiwas.booleantoolbox",
-      "version": "1.10.28",
+      "version": "1.10.29",
       "license": "ISC",
       "dependencies": {
         "homey-api": "3.17.0",

--- a/no.tiwas.booleantoolbox/package.json
+++ b/no.tiwas.booleantoolbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "no.tiwas.booleantoolbox",
-  "version": "1.10.28",
+  "version": "1.10.29",
   "main": "app.js",
   "dependencies": {
     "homey-api": "3.17.0",


### PR DESCRIPTION
## Summary\n- make process and OS resource probes best effort\n- isolate synchronous Homey API metric failures\n- publish unavailable values without aborting the report\n- prepare v1.10.29 release and Community notes\n\n## Verification\n- npm test -- --runInBand (19 suites, 210 tests)\n- npm run test:package (publish validation, 766 files, 7.51 MB, 17 assets)